### PR TITLE
Stream general improvements and database implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ target/
 .env
 
 *.db
+
+flamegraph.svg

--- a/.sqlx/query-b028521a1d2efb7113cd45e88d0118b38e58aaa900930e6de4c9d56dae80bc05.json
+++ b/.sqlx/query-b028521a1d2efb7113cd45e88d0118b38e58aaa900930e6de4c9d56dae80bc05.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                select\n                    state_version,\n                    round_timestamp,\n                    receipt_event_emitters,\n                    receipt_event_sbors,\n                    receipt_event_names,\n                    intent_hash\n                from\n                    ledger_transactions\n                where discriminator = 'user' and receipt_status != 'failed' and state_version >= $2\n                order by state_version asc\n                limit\n                $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state_version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "round_timestamp",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "receipt_event_emitters",
+        "type_info": "JsonbArray"
+      },
+      {
+        "ordinal": 3,
+        "name": "receipt_event_sbors",
+        "type_info": "ByteaArray"
+      },
+      {
+        "ordinal": 4,
+        "name": "receipt_event_names",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 5,
+        "name": "intent_hash",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b028521a1d2efb7113cd45e88d0118b38e58aaa900930e6de4c9d56dae80bc05"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 [[package]]
 name = "radix-client"
 version = "1.0.0"
-source = "git+https://github.com/ociswap/radix-client?branch=improve-builder-design#94485347b400d63a3a19d2779e51edf723d1912d"
+source = "git+https://github.com/ociswap/radix-client?branch=improve-builder-design#a72eb06138b0e95c69c2b8fe57a27303fa6d9e5b"
 dependencies = [
  "chrono",
  "duplicate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "byteorder"
@@ -362,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml",
 ]
 
 [[package]]
@@ -415,64 +415,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
-dependencies = [
- "async-trait",
- "convert_case",
- "json5",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde_json",
- "toml 0.8.12",
- "yaml-rust",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.13",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "const-sha1"
 version = "0.2.0"
 source = "git+https://github.com/radixdlt/const-sha1#5e9ae2a99e9c76e85aa67f42e4b62e7f7ce8dad4"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -546,12 +497,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -654,15 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,9 +606,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duplicate"
@@ -1283,17 +1219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,12 +1255,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1620,16 +1539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
-dependencies = [
- "dlv-list",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,12 +1568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,51 +1581,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pest"
-version = "2.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
-dependencies = [
- "once_cell",
- "pest",
- "sha2 0.10.8",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2057,7 +1915,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "colored",
- "config",
  "dyn-clone",
  "env_logger",
  "handler_macro",
@@ -2272,18 +2129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64",
- "bitflags 2.5.0",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,16 +2146,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -2368,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -3208,15 +3043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,18 +3135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.9",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,7 +3153,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.5.40",
+ "winnow",
 ]
 
 [[package]]
@@ -3350,20 +3164,7 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
-dependencies = [
- "indexmap 2.2.6",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.6.5",
+ "winnow",
 ]
 
 [[package]]
@@ -3438,12 +3239,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -3945,15 +3740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,15 +3756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,16 +1865,18 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix-client"
-version = "0.1.0"
-source = "git+https://github.com/ociswap/radix-client?branch=init-push#d1ce56f03bdc4847d472084a7f7523fd8a07dac7"
+version = "1.0.0"
+source = "git+https://github.com/ociswap/radix-client?branch=improve-builder-design#94485347b400d63a3a19d2779e51edf723d1912d"
 dependencies = [
  "chrono",
  "duplicate",
+ "log",
  "maybe-async",
  "reqwest",
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_path_to_error",
 ]
 
 [[package]]
@@ -2597,6 +2599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2837,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2848,6 +2861,7 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2885,6 +2899,7 @@ dependencies = [
  "sha2 0.10.8",
  "sqlx-core",
  "sqlx-mysql",
+ "sqlx-postgres",
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
@@ -2903,6 +2918,7 @@ dependencies = [
  "bitflags 2.5.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -2930,6 +2946,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2944,6 +2961,7 @@ dependencies = [
  "base64",
  "bitflags 2.5.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2968,6 +2986,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2979,6 +2998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2990,6 +3010,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
+ "time",
  "tracing",
  "url",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,14 @@ sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "038ddee8b0
 ] }
 radix-client = { git = "https://github.com/ociswap/radix-client", branch = "improve-builder-design", features = [
     "gateway",
-] }
+], optional = true }
 
 handler_macro = { path = "./handler_macro" }
 
 serde_json = "1.0.114"
-config = "0.14.0"
 serde = "1.0.197"
 log = "0.4.21"
-serde_yaml = "0.9.33"
+serde_yaml = { version = "0.9.33", optional = true }
 chrono = "0.4.35"
 colored = "2.1.0"
 dyn-clone = "1.0.17"
@@ -34,12 +33,19 @@ async-trait = "0.1.79"
 tokio = { version = "1.37.0", features = ["full"] }
 sqlx = { version = "0.7.4", features = [
     "postgres",
-    "sqlite",
     "time",
     "runtime-tokio",
     "chrono",
-] }
+], optional = true }
+
+[features]
+default = ["gateway", "file", "database", "channel"]
+database = ["sqlx"]
+gateway = ["radix-client"]
+file = ["serde_yaml"]
+channel = []
 
 
 [dev-dependencies]
+sqlx = { version = "0.7.4", features = ["sqlite"] }
 env_logger = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "radix-event-stream"
 version = "1.0.0"
 edition = "2021"
+license-file = "LICENSE"
+repository = "https://github.com/ociswap/radix-event-stream"
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", re
 sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "038ddee8b0f57aa90e36375c69946c4eb634efeb", features = [
     "serde",
 ] }
-radix-client = { git = "https://github.com/ociswap/radix-client", branch = "init-push", features = [
-    "gateway",
-] }
+radix-client = { git = "https://github.com/ociswap/radix-client", branch = "improve-builder-design" }
 
 handler_macro = { path = "./handler_macro" }
 
@@ -32,7 +30,13 @@ dyn-clone = "1.0.17"
 anyhow = "1.0.81"
 async-trait = "0.1.79"
 tokio = { version = "1.37.0", features = ["full"] }
+sqlx = { version = "0.7.4", features = [
+    "postgres",
+    "sqlite",
+    "time",
+    "runtime-tokio",
+    "chrono",
+] }
 
 [dev-dependencies]
 env_logger = "0.11.3"
-sqlx = { version = "0.7.4", features = ["sqlite", "runtime-tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", re
 sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "038ddee8b0f57aa90e36375c69946c4eb634efeb", features = [
     "serde",
 ] }
-radix-client = { git = "https://github.com/ociswap/radix-client", branch = "improve-builder-design" }
+radix-client = { git = "https://github.com/ociswap/radix-client", branch = "improve-builder-design", features = [
+    "gateway",
+] }
 
 handler_macro = { path = "./handler_macro" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,6 @@ sqlx = { version = "0.7.4", features = [
     "chrono",
 ] }
 
+
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ Above, we see an event definition used in one of Ociswap's Basic pools. It deriv
 
 ### Step 2: Define a global state.
 
-This will be mutably shared with every transaction handler. It should at least implement Clone. If you need to share this data with other pieces of code you may choose to store items wrapped in Rc, RefCell, Arc, Mutex, etc.
+This will be mutably shared with every transaction handler. If you need to share this data with other pieces of code you may choose to store items wrapped in Rc, RefCell, Arc, Mutex, etc.
 
 ```rust
-#[derive(Clone)]
 struct State {
     instantiate_events_seen: u64
 }
@@ -119,7 +118,7 @@ A concrete example:
 ```Rust
 #[event_handler]
 async fn handle_instantiate_event(
-    context: EventHandlerContext<AppState>,
+    context: EventHandlerContext<State>,
     event: InstantiateEvent,
 ) -> Result<(), EventHandlerError> {
     info!(
@@ -157,8 +156,7 @@ By returning different errors, you may control how the stream behaves. It can re
 Create a handler registry:
 
 ```Rust
-let mut handler_registry: HandlerRegistry<AppState> =
-    HandlerRegistry::new();
+let mut handler_registry = HandlerRegistry::new();
 ```
 
 Add any handlers to the registry, identified by emitters and event names. In this case, we would like to handle `InstantiateEvent` events emitted by Ociswap's Basic pool package address.
@@ -226,7 +224,7 @@ async fn transaction_handler_name(
     // and the global state. It is parametrized by the
     // app state and the transaction context type, but the context is optional,
     // and defaults to the unit type.
-    context: TransactionHandlerContext<YOUR_STATE, YOUR_TRANSACTION_CONTEXT_TYPE>,
+    context: TransactionHandlerContext<YOUR_STATE>,
 ) -> Result<(), TransactionHandlerError> {
     // Do something like start a database transaction
     let mut transaction_context = TransactionContext { tx: start_transaction() }
@@ -267,7 +265,7 @@ Simplest concrete example:
 ```rust
 #[transaction_handler]
 async fn transaction_handler(
-    context: TransactionHandlerContext<AppState, ()>,
+    context: TransactionHandlerContext<State>,
 ) -> Result<(), TransactionHandlerError> {
     // Do something before handling events
     context

--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -4,7 +4,7 @@ use radix_engine_common::types::{ComponentAddress, ResourceAddress};
 use radix_engine_common::ScryptoSbor;
 use radix_event_stream::event_handler::HandlerRegistry;
 use radix_event_stream::macros::event_handler;
-use radix_event_stream::processor::SimpleTransactionStreamProcessor;
+use radix_event_stream::processor::TransactionStreamProcessor;
 use radix_event_stream::sources::channel::ChannelTransactionStream;
 use radix_event_stream::sources::gateway::GatewayTransactionStream;
 use radix_event_stream::stream::TransactionStream;
@@ -87,11 +87,12 @@ async fn main() {
     });
 
     // Start with parameters.
-    SimpleTransactionStreamProcessor::run_with(
+    TransactionStreamProcessor::new(
         channel_stream,
         handler_registry,
         State { number: 1 },
     )
+    .run()
     .await
     .unwrap();
 }

--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -54,12 +54,11 @@ async fn main() {
 
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
-    let mut gateway_stream = GatewayTransactionStream::new(
-        1919391,
-        "https://mainnet.radixdlt.com".to_string(),
-        100,
-        1000,
-    );
+    let mut gateway_stream = GatewayTransactionStream::new()
+        .from_state_version(71500000)
+        .gateway_url("https://mainnet.radixdlt.com".to_string())
+        .buffer_capacity(1000)
+        .limit_per_page(100);
 
     // creating a new channel stream, which gives back a sender side.
     let (channel_stream, sender) = ChannelTransactionStream::new(100);

--- a/examples/database.rs
+++ b/examples/database.rs
@@ -53,12 +53,13 @@ async fn main() {
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
     let stream = DatabaseTransactionStream::new(
+        // This database is public, but I would recommend not using it for anything outside
+        // of testing.
         "postgresql://radix:radix@db.radix.live/radix_ledger".to_string(),
-        1919391,
-        100000,
-        1000000,
     )
-    .await;
+    .from_state_version(1919391)
+    .buffer_capacity(1_000_000)
+    .limit_per_page(100_000);
 
     // Start with parameters.
     SimpleTransactionStreamProcessor::run_with(

--- a/examples/database.rs
+++ b/examples/database.rs
@@ -4,7 +4,7 @@ use radix_engine_common::types::{ComponentAddress, ResourceAddress};
 use radix_engine_common::ScryptoSbor;
 use radix_event_stream::event_handler::HandlerRegistry;
 use radix_event_stream::macros::event_handler;
-use radix_event_stream::processor::SimpleTransactionStreamProcessor;
+use radix_event_stream::processor::TransactionStreamProcessor;
 use radix_event_stream::sources::database::DatabaseTransactionStream;
 use std::env;
 
@@ -62,11 +62,12 @@ async fn main() {
     .limit_per_page(100_000);
 
     // Start with parameters.
-    SimpleTransactionStreamProcessor::run_with(
+    TransactionStreamProcessor::new(
         stream,
         handler_registry,
         State { number: 1 },
     )
+    .run()
     .await
     .unwrap();
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -52,12 +52,11 @@ async fn main() {
 
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
-    let stream = GatewayTransactionStream::new(
-        71500000,
-        "https://mainnet.radixdlt.com".to_string(),
-        100,
-        1000,
-    );
+    let stream = GatewayTransactionStream::new()
+        .gateway_url("https://mainnet.radixdlt.com".to_string())
+        .from_state_version(71500000)
+        .buffer_capacity(1000)
+        .limit_per_page(100);
 
     // Start with parameters.
     SimpleTransactionStreamProcessor::run_with(

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -53,9 +53,10 @@ async fn main() {
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
     let stream = GatewayTransactionStream::new(
-        1919391,
-        100,
+        71500000,
         "https://mainnet.radixdlt.com".to_string(),
+        100,
+        1000,
     );
 
     // Start with parameters.

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -4,7 +4,7 @@ use radix_engine_common::types::{ComponentAddress, ResourceAddress};
 use radix_engine_common::ScryptoSbor;
 use radix_event_stream::event_handler::HandlerRegistry;
 use radix_event_stream::macros::event_handler;
-use radix_event_stream::processor::SimpleTransactionStreamProcessor;
+use radix_event_stream::processor::TransactionStreamProcessor;
 use radix_event_stream::sources::gateway::GatewayTransactionStream;
 use std::env;
 
@@ -59,11 +59,12 @@ async fn main() {
         .limit_per_page(100);
 
     // Start with parameters.
-    SimpleTransactionStreamProcessor::run_with(
+    TransactionStreamProcessor::new(
         stream,
         handler_registry,
         State { number: 1 },
     )
+    .run()
     .await
     .unwrap();
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -41,7 +41,7 @@ async fn main() {
     env_logger::init();
 
     // Create a new handler registry
-    let mut handler_registry: HandlerRegistry<State> = HandlerRegistry::new();
+    let mut handler_registry: HandlerRegistry = HandlerRegistry::new();
 
     // Add the instantiate event handler to the registry
     handler_registry.add_handler(

--- a/examples/pools/basicv0/events.rs
+++ b/examples/pools/basicv0/events.rs
@@ -44,7 +44,6 @@ async fn handle_instantiate_event(
         &context.state.network,
     )
     .map_err(|err| EventHandlerError::UnrecoverableError(err.into()))?;
-
     add_to_database(
         context.transaction_context,
         context.event.binary_sbor_data.clone(),

--- a/examples/pools/basicv0/events.rs
+++ b/examples/pools/basicv0/events.rs
@@ -5,7 +5,7 @@ use radix_engine_common::{
     ScryptoSbor,
 };
 use radix_event_stream::macros::event_handler;
-use radix_event_stream::{encodings::encode_bech32, error::EventHandlerError};
+use radix_event_stream::{encodings::encode_bech32m, error::EventHandlerError};
 use sbor::rust::collections::IndexMap;
 
 async fn add_to_database(
@@ -34,12 +34,12 @@ async fn handle_instantiate_event(
     context: EventHandlerContext<State, TransactionContext>,
     event: InstantiateEvent,
 ) -> Result<(), EventHandlerError> {
-    let component_address = encode_bech32(
+    let component_address = encode_bech32m(
         event.pool_address.as_node_id().as_bytes(),
         &context.state.network,
     )
     .map_err(|err| EventHandlerError::EventRetryError(err.into()))?;
-    let native_address = encode_bech32(
+    let native_address = encode_bech32m(
         event.liquidity_pool_address.as_node_id().as_bytes(),
         &context.state.network,
     )

--- a/examples/pools/basicv0/events.rs
+++ b/examples/pools/basicv0/events.rs
@@ -78,13 +78,13 @@ pub async fn handle_swap_event(
     context: EventHandlerContext<State, TransactionContext>,
     event: SwapEvent,
 ) -> Result<(), EventHandlerError> {
-    // info!("Handling swap event: {:#?}", event);
     add_to_database(
         context.transaction_context,
         context.event.binary_sbor_data.clone(),
     )
     .await
     .map_err(|err| EventHandlerError::UnrecoverableError(err.into()))?;
+
     Ok(())
 }
 

--- a/examples/pools/main.rs
+++ b/examples/pools/main.rs
@@ -132,12 +132,11 @@ async fn run_from_gateway(
 ) {
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
-    let stream = GatewayTransactionStream::new(
-        1919391,
-        "https://mainnet.radixdlt.com".to_string(),
-        100,
-        1000,
-    );
+    let stream = GatewayTransactionStream::new()
+        .gateway_url("https://mainnet.radixdlt.com".to_string())
+        .from_state_version(1919391)
+        .buffer_capacity(1000)
+        .limit_per_page(100);
 
     // Start with parameters.
     TransactionStreamProcessor::run_with(
@@ -162,13 +161,15 @@ async fn run_from_database(
 ) {
     // Create a new transaction stream, which the processor will use
     // as a source of transactions.
+
     let stream = DatabaseTransactionStream::new(
+        // This database is public, but I would recommend not using it for anything outside
+        // of testing.
         "postgresql://radix:radix@db.radix.live/radix_ledger".to_string(),
-        1919391,
-        10000,
-        1000000,
     )
-    .await;
+    .from_state_version(1919391)
+    .buffer_capacity(1_000_000)
+    .limit_per_page(100_000);
 
     // Start with parameters.
     TransactionStreamProcessor::run_with(

--- a/examples/pools/main.rs
+++ b/examples/pools/main.rs
@@ -14,6 +14,7 @@ use radix_event_stream::{
 use sqlx::{sqlite::SqlitePoolOptions, Pool, Sqlite};
 use std::env;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
@@ -163,7 +164,7 @@ async fn run_from_database(
     )
     .from_state_version(1919391)
     .buffer_capacity(1_000_000)
-    .limit_per_page(100_000);
+    .limit_per_page(10_000);
 
     let state = State {
         number: 0,
@@ -174,7 +175,7 @@ async fn run_from_database(
     // Start with parameters.
     TransactionStreamProcessor::new(stream, handler_registry, state)
         .transaction_handler(transaction_handler)
-        .current_state_report_interval_ms(1000)
+        .default_logger_with_report_interval(Duration::from_millis(500))
         .run()
         .await
         .unwrap();

--- a/examples/pools/main.rs
+++ b/examples/pools/main.rs
@@ -67,7 +67,7 @@ async fn main() {
 
         // Handle the events in the transaction
         context
-            .transaction
+            .event_processor
             .process_events(
                 context.state,
                 context.handler_registry,
@@ -107,19 +107,18 @@ async fn run_from_file(
         "examples/pools/transactions.json".to_string(),
     );
 
+    let state = State {
+        number: 0,
+        pool: Arc::new(pool),
+        network: NetworkDefinition::mainnet(),
+    };
+
     // Start with parameters.
-    TransactionStreamProcessor::run_with(
-        stream,
-        handler_registry,
-        transaction_handler,
-        State {
-            number: 0,
-            pool: Arc::new(pool),
-            network: NetworkDefinition::mainnet(),
-        },
-    )
-    .await
-    .unwrap();
+    TransactionStreamProcessor::new(stream, handler_registry, state)
+        .transaction_handler(transaction_handler)
+        .run()
+        .await
+        .unwrap();
 }
 
 async fn run_from_gateway(
@@ -135,19 +134,18 @@ async fn run_from_gateway(
         .buffer_capacity(1000)
         .limit_per_page(100);
 
+    let state = State {
+        number: 0,
+        pool: Arc::new(pool),
+        network: NetworkDefinition::mainnet(),
+    };
+
     // Start with parameters.
-    TransactionStreamProcessor::run_with(
-        stream,
-        handler_registry,
-        transaction_handler,
-        State {
-            number: 0,
-            pool: Arc::new(pool),
-            network: NetworkDefinition::mainnet(),
-        },
-    )
-    .await
-    .unwrap();
+    TransactionStreamProcessor::new(stream, handler_registry, state)
+        .transaction_handler(transaction_handler)
+        .run()
+        .await
+        .unwrap();
 }
 
 async fn run_from_database(
@@ -167,17 +165,17 @@ async fn run_from_database(
     .buffer_capacity(1_000_000)
     .limit_per_page(100_000);
 
+    let state = State {
+        number: 0,
+        pool: Arc::new(pool),
+        network: NetworkDefinition::mainnet(),
+    };
+
     // Start with parameters.
-    TransactionStreamProcessor::run_with(
-        stream,
-        handler_registry,
-        transaction_handler,
-        State {
-            number: 0,
-            pool: Arc::new(pool),
-            network: NetworkDefinition::mainnet(),
-        },
-    )
-    .await
-    .unwrap();
+    TransactionStreamProcessor::new(stream, handler_registry, state)
+        .transaction_handler(transaction_handler)
+        .current_state_report_interval_ms(1000)
+        .run()
+        .await
+        .unwrap();
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,0 +1,3 @@
+fn main() {}
+
+struct State {}

--- a/handler_macro/src/lib.rs
+++ b/handler_macro/src/lib.rs
@@ -68,9 +68,9 @@ pub fn event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
             async fn handle(
                 &self,
                 context: radix_event_stream::event_handler::EventHandlerContext<'_, #generics_handling>,
-                event: Vec<u8>,
+                event: &[u8],
             ) -> Result<(), radix_event_stream::error::EventHandlerError> {
-                let event: #event_type = radix_event_stream::scrypto_decode(&event).map_err(|error| {
+                let event: #event_type = radix_event_stream::scrypto_decode(event).map_err(|error| {
                     radix_event_stream::error::EventHandlerError::UnrecoverableError(radix_event_stream::anyhow!("Failed to decode event: {:?}", error))
                 })?;
                 #function_body

--- a/src/encodings.rs
+++ b/src/encodings.rs
@@ -31,10 +31,10 @@ pub fn programmatic_json_to_bytes(
     Ok(string_representation.to_vec())
 }
 
-/// Encode a byte slice into a bech32 string representation.
+/// Encode a byte slice into a bech32m string representation.
 /// Useful for easily encoding addresses to the proper network
-/// string format.
-pub fn encode_bech32(
+/// string format.e
+pub fn encode_bech32m(
     data: &[u8],
     network: &NetworkDefinition,
 ) -> Result<String, AddressBech32EncodeError> {

--- a/src/encodings.rs
+++ b/src/encodings.rs
@@ -1,3 +1,6 @@
+//! Some utility functions for encoding and decoding data
+//! using the Scrypto SBOR encoding.
+
 use radix_engine_common::{
     address::{AddressBech32EncodeError, AddressBech32Encoder},
     data::scrypto::{scrypto_decode, ScryptoDecode},
@@ -7,8 +10,8 @@ use radix_engine_toolkit::functions::scrypto_sbor::{
     encode_string_representation, ScryptoSborError, StringRepresentation,
 };
 
-/// Decode a serde json value containing programmatic json
-/// into a type that implements the `ScryptoDecode` trait.
+/// Decode a [`serde_json::Value`] containing programmatic json
+/// into a type that implements the [`ScryptoDecode`] trait.
 #[allow(clippy::redundant_closure)]
 pub fn decode_programmatic_json<T: ScryptoDecode>(
     data: &serde_json::Value,
@@ -19,8 +22,8 @@ pub fn decode_programmatic_json<T: ScryptoDecode>(
 }
 
 /// Some representations of transactions only come with programmatic
-/// json data. This function converts the programmatic json data into
-/// binary SBOR representation.
+/// json data. This function converts a [`serde_json::Value`] containing
+/// programmatic json into a binary SBOR representation.
 pub fn programmatic_json_to_bytes(
     data: &serde_json::Value,
 ) -> Result<Vec<u8>, ScryptoSborError> {
@@ -33,7 +36,7 @@ pub fn programmatic_json_to_bytes(
 
 /// Encode a byte slice into a bech32m string representation.
 /// Useful for easily encoding addresses to the proper network
-/// string format.e
+/// string format.
 pub fn encode_bech32m(
     data: &[u8],
     network: &NetworkDefinition,

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,10 +40,10 @@ impl From<EventHandlerError> for TransactionHandlerError {
                 panic!("Event retries should be handled at the event level, not the transaction level")
             }
             EventHandlerError::TransactionRetryError(e) => {
-                TransactionHandlerError::TransactionRetryError(e)
+                Self::TransactionRetryError(e)
             }
             EventHandlerError::UnrecoverableError(e) => {
-                TransactionHandlerError::UnrecoverableError(e)
+                Self::UnrecoverableError(e)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error types for event handlers, transaction handlers, and processors.
+
 /// Error type which is returned from an event
 /// handler by the user on failure.
 #[derive(Debug)]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -79,6 +79,7 @@ impl<T> State for T where T: Send + Sync + 'static {}
 /// that allows some other types to be a bit simpler.
 /// It can only contain event handlers of one specific type, which is
 /// implicitly determined by the first handler that is added to the registry.
+#[derive(Default)]
 pub struct HandlerRegistry {
     handlers: HashMap<(String, String), Box<dyn Any + Send + Sync>>,
     type_id: Option<TypeId>,
@@ -87,10 +88,7 @@ pub struct HandlerRegistry {
 #[allow(non_camel_case_types)]
 impl HandlerRegistry {
     pub fn new() -> Self {
-        HandlerRegistry {
-            handlers: HashMap::new(),
-            type_id: None,
-        }
+        Self::default()
     }
 
     pub fn handler_exists(&self, emitter: &str, name: &str) -> bool {
@@ -142,6 +140,7 @@ impl HandlerRegistry {
     ///
     /// This function panics if the type parameters used to call it
     /// don't match the ones used to add the handler to the registry.
+    #[allow(clippy::borrowed_box)]
     pub fn get_handler<STATE: State, TRANSACTION_CONTEXT: 'static>(
         &self,
         emitter: &str,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -33,7 +33,7 @@ impl HandlerRegistry {
             .contains_key(&(emitter.to_string(), name.to_string()))
     }
 
-    pub fn add_handler<STATE: Clone + 'static, TRANSACTION_CONTEXT: 'static>(
+    pub fn add_handler<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
         &mut self,
         emitter: &str,
         name: &str,
@@ -62,7 +62,7 @@ impl HandlerRegistry {
             .insert((emitter.to_string(), name.to_string()), Box::new(boxed));
     }
 
-    pub fn get_handler<STATE: Clone + 'static, TRANSACTION_CONTEXT: 'static>(
+    pub fn get_handler<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
         &self,
         emitter: &str,
         name: &str,
@@ -93,8 +93,6 @@ impl HandlerRegistry {
 #[async_trait]
 pub trait EventHandler<STATE, TRANSACTION_CONTEXT>:
     DynClone + Send + Sync
-where
-    STATE: Clone,
 {
     async fn handle(
         &self,
@@ -106,8 +104,6 @@ where
 #[allow(non_camel_case_types)]
 impl<STATE, TRANSACTION_CONTEXT> Clone
     for Box<dyn EventHandler<STATE, TRANSACTION_CONTEXT>>
-where
-    STATE: Clone,
 {
     fn clone(&self) -> Self {
         dyn_clone::clone_box(&**self)
@@ -117,10 +113,7 @@ where
 /// A struct that holds the context for an event handler,
 /// which is passed to the handler when it is called.
 #[allow(non_camel_case_types)]
-pub struct EventHandlerContext<'a, STATE, TRANSACTION_CONTEXT = ()>
-where
-    STATE: Clone,
-{
+pub struct EventHandlerContext<'a, STATE, TRANSACTION_CONTEXT = ()> {
     pub state: &'a mut STATE,
     pub transaction: &'a Transaction,
     pub event: &'a Event,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -192,6 +192,10 @@ impl<STATE, TRANSACTION_CONTEXT> Clone
 
 /// A struct that holds the context for an event handler,
 /// which is passed to the handler when it is called.
+///
+/// STATE: The global state of the application.
+/// TRANSACTION_CONTEXT: A type containing context of a current transaction, like
+/// a database transaction handle. This is optional and defaults to the unit type.
 #[allow(non_camel_case_types)]
 pub struct EventHandlerContext<'a, STATE, TRANSACTION_CONTEXT = ()> {
     pub state: &'a mut STATE,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,6 +1,61 @@
+/*!
+The interface for an [`EventHandler`]
+
+Event handlers are responsible for processing single event types.
+We don't generally have to create a separate struct
+and implement this trait for it manually, because we can use
+the `#[event_handler]` macro to generate the
+struct and implementation for us. It allows us to write
+the handler as an async function, which is a bit more
+ergonomic.
+
+To use this macro, the handler function must conform to a predefined
+signature.
+An event handler function must:
+- Be an async function
+- Take a `context` parameter of type [`EventHandlerContext<YOUR_STATE>`]
+- Take an `event` parameter of the type of your Radix Engine event struct which derives [`radix_engine_common::ScryptoSbor`]
+- Return a `Result<(), EventHandlerError>`
+
+You can use the following template to create an event handler:
+
+```ignore
+// A macro from the crate which transforms the handler function
+// into a representation that is usable for the framework.
+#[event_handler]
+// The function name is the name of your handler
+async fn event_handler_name(
+    // Context the handler will get from the framework.
+    // This includes the current ledger transaction we're in,
+    // the raw event, the global state, and the transaction context.
+    context: EventHandlerContext<YOUR_STATE>,
+    // The decoded event struct as defined in your smart contract.
+    event: EVENT_STRUCT,
+) -> Result<(), EventHandlerError> {
+    // Handle the event here.
+
+    // Possible errors to return:
+    // Retry handling the current event
+    return Err(EventHandlerError::EventRetryError(
+        anyhow!("Retry event because of...")
+    ));
+    // Retry handling the current transaction
+    return Err(EventHandlerError::TransactionRetryError(
+        anyhow!("Retry transaction because of...")
+    ));
+    // Stop the stream
+    return Err(EventHandlerError::UnrecoverableError(
+        anyhow!("Stream failed because of...")
+    ));
+    // Everything's ok!
+    Ok(())
+}
+```
+
+*/
+
 use async_trait::async_trait;
 use dyn_clone::DynClone;
-// use scrypto::prelude::*;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
@@ -11,12 +66,22 @@ use crate::{
     models::{Event, Transaction},
 };
 
+/// A shorthand trait for a state type that can be used in event handlers.
+/// It's used to enforce that the state type is Send + Sync + 'static without having
+/// to write it out every time.
+pub trait State: Send + Sync + 'static {}
+
+// Implement the State trait for all types that are Send + Sync + 'static.
+impl<T> State for T where T: Send + Sync + 'static {}
+
 /// A type-erased registry of event handlers. It is not parametrized by the
 /// state and transaction context types, which is a nice property
 /// that allows some other types to be a bit simpler.
+/// It can only contain event handlers of one specific type, which is
+/// implicitly determined by the first handler that is added to the registry.
 pub struct HandlerRegistry {
-    pub handlers: HashMap<(String, String), Box<dyn Any + Send + Sync>>,
-    pub type_id: Option<TypeId>,
+    handlers: HashMap<(String, String), Box<dyn Any + Send + Sync>>,
+    type_id: Option<TypeId>,
 }
 
 #[allow(non_camel_case_types)]
@@ -33,7 +98,15 @@ impl HandlerRegistry {
             .contains_key(&(emitter.to_string(), name.to_string()))
     }
 
-    pub fn add_handler<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
+    /// Add an event handler to the registry.
+    /// It is only possible to add handlers with the same signature.
+    /// The signature is determined by the first handler that is added to the registry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the added handler has a different signature than the
+    /// handlers already in the registry.
+    pub fn add_handler<STATE: State, TRANSACTION_CONTEXT: 'static>(
         &mut self,
         emitter: &str,
         name: &str,
@@ -62,7 +135,14 @@ impl HandlerRegistry {
             .insert((emitter.to_string(), name.to_string()), Box::new(boxed));
     }
 
-    pub fn get_handler<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
+    /// Get an event handler from the registry.
+    /// The handler is downcast to the correct type.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the type parameters used to call it
+    /// don't match the ones used to add the handler to the registry.
+    pub fn get_handler<STATE: State, TRANSACTION_CONTEXT: 'static>(
         &self,
         emitter: &str,
         name: &str,
@@ -97,7 +177,7 @@ pub trait EventHandler<STATE, TRANSACTION_CONTEXT>:
     async fn handle(
         &self,
         input: EventHandlerContext<'_, STATE, TRANSACTION_CONTEXT>,
-        event: Vec<u8>,
+        event: &[u8],
     ) -> Result<(), EventHandlerError>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod encodings;
 pub mod error;
 pub mod event_handler;
+pub mod logger;
 pub mod macros;
 pub mod models;
 pub mod processor;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -34,7 +34,7 @@ pub struct StreamMetrics {
 
 impl Default for StreamMetrics {
     fn default() -> Self {
-        StreamMetrics {
+        Self {
             transactions_seen: 0,
             events_seen: 0,
             transactions_handled: 0,
@@ -153,7 +153,7 @@ pub struct DefaultLogger {
 
 impl Default for DefaultLogger {
     fn default() -> Self {
-        DefaultLogger {
+        Self {
             metrics: StreamMetrics::default(),
             transaction_stopwatch: Instant::now(),
             event_stopwatch: Instant::now(),
@@ -166,9 +166,9 @@ impl DefaultLogger {
     pub fn with_custom_report_interval(
         custom_report_interval: Duration,
     ) -> Self {
-        DefaultLogger {
+        Self {
             custom_report_interval: Some(custom_report_interval),
-            ..DefaultLogger::default()
+            ..Self::default()
         }
     }
 }
@@ -359,10 +359,7 @@ impl Logger for DefaultLogger {
     }
 
     fn periodic_report_interval(&self) -> Duration {
-        if let Some(interval) = self.custom_report_interval {
-            interval
-        } else {
-            Duration::from_secs(5)
-        }
+        self.custom_report_interval
+            .unwrap_or(Duration::from_secs(5))
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -338,7 +338,7 @@ impl Logger for DefaultLogger {
                     .fold(Duration::from_secs(0), |acc, (_, duration)| {
                         acc + *duration
                     })
-                    / transaction_amount.min(1) as u32;
+                    / transaction_amount.max(1) as u32;
                 let time_per_transaction_message = format!(
                     "AVERAGE TIME PER TRANSACTION: ~{:?}",
                     time_per_transaction

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -196,7 +196,10 @@ impl Logger for DefaultLogger {
                     .expect("When handling a transaction it should always have a timestamp")
                     .format("%a %d-%m-%Y %H:%M")
             ).bright_green();
+            let transaction_id =
+                format!("{}", transaction.intent_hash).bright_green();
             info!("{}", message);
+            info!("{}", transaction_id);
         }
     }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -226,8 +226,8 @@ impl Logger for DefaultLogger {
         if handling {
             self.metrics.transactions_handled += 1;
             let message = format!(
-                "###### END TRANSACTION - HANDLED IN {}ms ######",
-                time_spent.as_millis()
+                "###### END TRANSACTION - HANDLED IN {:?} ######",
+                time_spent
             )
             .bright_green();
             let line =

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -338,7 +338,7 @@ impl Logger for DefaultLogger {
                     .fold(Duration::from_secs(0), |acc, (_, duration)| {
                         acc + *duration
                     })
-                    / transaction_amount as u32;
+                    / transaction_amount.min(1) as u32;
                 let time_per_transaction_message = format!(
                     "AVERAGE TIME PER TRANSACTION: ~{:?}",
                     time_per_transaction

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,368 @@
+/*!
+This module contains the [`Logger`] trait and the [`DefaultLogger`] implementation.
+
+The [`Logger`] trait is an interface of hooks called by the [`TransactionStreamProcessor`][crate::processor::TransactionStreamProcessor]
+at various points in the processing of transactions. This allows for custom logging
+and metric collection. The default implementation is [`DefaultLogger`].
+*/
+
+use crate::models::{Event, Transaction};
+use async_trait::async_trait;
+use chrono::Utc;
+use colored::Colorize;
+use log::{error, info};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+/// The interval at which the metrics are considered for the
+/// `transactions_per_second` and `micros_per_transaction_message` metrics.
+const METRIC_CONSIDERATION_INTERVAL_S: u64 = 10;
+
+/// A struct that holds metrics about the transaction stream in the [`DefaultLogger`]
+pub struct StreamMetrics {
+    pub transactions_seen: u64,
+    pub transactions_handled: u64,
+    pub events_seen: u64,
+    pub events_handled: u64,
+    pub time_started: Instant,
+    pub last_seen_state_version: Option<u64>,
+    pub last_seen_timestamp: Option<chrono::DateTime<Utc>>,
+    pub recent_transactions: VecDeque<(Instant, Duration)>,
+}
+
+impl Default for StreamMetrics {
+    fn default() -> Self {
+        StreamMetrics {
+            transactions_seen: 0,
+            events_seen: 0,
+            transactions_handled: 0,
+            events_handled: 0,
+            time_started: Instant::now(),
+            last_seen_state_version: None,
+            last_seen_timestamp: None,
+            recent_transactions: VecDeque::new(),
+        }
+    }
+}
+
+/// An interface of hooks for the `TransactionStreamProcessor` to call
+/// at various points in the processing of transactions.
+/// This allows for custom logging and metric collection.
+/// The default implementation is `DefaultLogger`.
+#[async_trait]
+pub trait Logger: Send + Sync {
+    /// Called when:
+    /// - A transaction is received from the stream and is about to be processed, because one
+    /// of its events has a handler associated with it.
+    /// - The transaction is received from the stream and will not be processed because
+    /// none of its events have a handler associated with them.
+    /// - A retry error was returned from a handler and the transaction is being retried.
+    ///
+    /// `handling` indicates whether the transaction has any events that will be handled by an event handler or not.
+    /// `is_retry` indicates whether the transaction is currently being retried or not.
+    async fn receive_transaction(
+        &mut self,
+        transaction: &Transaction,
+        handling: bool,
+        is_retry: bool,
+    );
+    /// Called when:
+    /// - A transaction has been processed and all of its events have been handled.
+    /// - A transaction has been processed, but nothing was done with it because
+    ///  none of its events had a handler associated with them.
+    /// - A transaction has been retried and is now successfully processed.
+    ///
+    /// `handling` indicates whether the transaction had any events that were handled by an event handler or not.
+    async fn finish_transaction(
+        &mut self,
+        transaction: &Transaction,
+        handling: bool,
+    );
+    /// Called when:
+    /// - An event is received from the stream and is about to be processed.
+    /// - An event is received from the stream and will not be processed because
+    /// it has no handler associated with it.
+    /// - A retry error was returned from a handler and the event is being retried.
+    ///
+    /// `handling` indicates whether the event will be handled by a handler or not.
+    /// `is_retry` indicates whether the event is currently being retried or not.
+    async fn receive_event(
+        &mut self,
+        transaction: &Transaction,
+        event: &Event,
+        handling: bool,
+        is_retry: bool,
+    );
+    /// Called when:
+    /// - An event has been processed.
+    /// - An event has been processed, but nothing was done with it because
+    /// it had no handler associated with it.
+    /// - An event has been retried and is now successfully processed.
+    ///
+    /// `handling` indicates whether the event was handled by a handler or not.
+    async fn finish_event(
+        &mut self,
+        transaction: &Transaction,
+        event: &Event,
+        handling: bool,
+    );
+    /// Called when an `EventRetryError` is returned from a handler
+    /// and the event is being retried. It could be called multiple times
+    /// for the same event if it continues to fail.
+    async fn event_retry_error(
+        &mut self,
+        transaction: &Transaction,
+        event: &Event,
+        error: &anyhow::Error,
+        timeout: Duration,
+    );
+    /// Called when a `TransactionRetryError` is returned from a handler
+    /// and the transaction is being retried.
+    /// It could be called multiple times for the same transaction if it continues to fail.
+    async fn transaction_retry_error(
+        &mut self,
+        transaction: &Transaction,
+        error: &anyhow::Error,
+        timeout: Duration,
+    );
+    /// Called when an `UnrecoverableError` is returned from a handler
+    /// and the processor should stop processing.
+    async fn unrecoverable_error(&mut self, error: &anyhow::Error);
+    /// Called periodically by an independent task. This is useful for
+    /// logging and metric collection. It is possible to set a custom
+    /// interval by implementing the `periodic_report_interval` method.
+    async fn periodic_report(&self);
+    /// Called by the processor to determine the interval at which
+    /// the `periodic_report` method should be called inside of
+    /// an independent task.
+    fn periodic_report_interval(&self) -> Duration;
+}
+
+/// The default logger implementation for the `TransactionStreamProcessor`.
+/// This logger collects some metrics about the transaction stream
+/// and logs them periodically. It also logs information about transactions
+/// and events as they are processed.
+pub struct DefaultLogger {
+    metrics: StreamMetrics,
+    transaction_stopwatch: Instant,
+    event_stopwatch: Instant,
+    custom_report_interval: Option<Duration>,
+}
+
+impl Default for DefaultLogger {
+    fn default() -> Self {
+        DefaultLogger {
+            metrics: StreamMetrics::default(),
+            transaction_stopwatch: Instant::now(),
+            event_stopwatch: Instant::now(),
+            custom_report_interval: None,
+        }
+    }
+}
+
+impl DefaultLogger {
+    pub fn with_custom_report_interval(
+        custom_report_interval: Duration,
+    ) -> Self {
+        DefaultLogger {
+            custom_report_interval: Some(custom_report_interval),
+            ..DefaultLogger::default()
+        }
+    }
+}
+
+#[async_trait]
+impl Logger for DefaultLogger {
+    async fn receive_transaction(
+        &mut self,
+        transaction: &Transaction,
+        handling: bool,
+        retry: bool,
+    ) {
+        self.transaction_stopwatch = Instant::now();
+        if handling {
+            if !retry {
+                let line =
+                    "--------------------------------------------------------"
+                        .bright_blue();
+                info!("{}", line);
+            }
+            let message = format!(
+                "HANDLING TRANSACTION - {:#?} - {}",
+                transaction.state_version,
+                transaction.confirmed_at
+                    .expect("When handling a transaction it should always have a timestamp")
+                    .format("%a %d-%m-%Y %H:%M")
+            ).bright_green();
+            info!("{}", message);
+        }
+    }
+
+    async fn finish_transaction(
+        &mut self,
+        transaction: &Transaction,
+        handling: bool,
+    ) {
+        self.metrics.transactions_seen += 1;
+        self.metrics.last_seen_state_version = Some(transaction.state_version);
+        self.metrics.last_seen_timestamp = transaction.confirmed_at;
+        let time_spent = self.transaction_stopwatch.elapsed();
+        self.metrics
+            .recent_transactions
+            .push_back((Instant::now(), time_spent));
+        let threshold = Instant::now()
+            - Duration::from_secs(METRIC_CONSIDERATION_INTERVAL_S);
+        while let Some(&(time, _)) = self.metrics.recent_transactions.front() {
+            if time < threshold {
+                self.metrics.recent_transactions.pop_front();
+            } else {
+                break;
+            }
+        }
+        if handling {
+            self.metrics.transactions_handled += 1;
+            let message = format!(
+                "###### END TRANSACTION - HANDLED IN {}ms ######",
+                time_spent.as_millis()
+            )
+            .bright_green();
+            let line =
+                "--------------------------------------------------------"
+                    .bright_blue();
+            info!("{}", message);
+            info!("{}", line);
+        }
+    }
+
+    async fn receive_event(
+        &mut self,
+        _transaction: &Transaction,
+        event: &Event,
+        handling: bool,
+        _retry: bool,
+    ) {
+        if handling {
+            self.event_stopwatch = Instant::now();
+            let message =
+                format!("HANDLING EVENT: {}", event.name).bright_yellow();
+            info!("{}", message);
+        }
+    }
+
+    async fn finish_event(
+        &mut self,
+        _transaction: &Transaction,
+        _event: &Event,
+        handling: bool,
+    ) {
+        self.metrics.events_seen += 1;
+        if handling {
+            self.metrics.events_handled += 1;
+        }
+    }
+
+    async fn event_retry_error(
+        &mut self,
+        _transaction: &Transaction,
+        event: &Event,
+        error: &anyhow::Error,
+        timeout: Duration,
+    ) {
+        let message =
+            format!("ERROR HANDLING EVENT: {} - {:?}", event.name, error)
+                .bright_red();
+        let retry_message =
+            format!("RETRYING IN {:.1} SECONDS\n", timeout.as_secs_f32())
+                .bright_yellow();
+
+        error!("{}", message);
+        info!("{}", retry_message);
+    }
+
+    async fn transaction_retry_error(
+        &mut self,
+        _transaction: &Transaction,
+        error: &anyhow::Error,
+        timeout: Duration,
+    ) {
+        let message =
+            format!("FATAL ERROR HANDLING TRANSACTION: {:?}\n", error)
+                .bright_red();
+
+        let retry_message =
+            format!("RETRYING IN {:.1} SECONDS\n", timeout.as_secs_f32())
+                .bright_yellow();
+
+        error!("{}", message);
+        info!("{}", retry_message);
+    }
+
+    async fn unrecoverable_error(&mut self, error: &anyhow::Error) {
+        let message = format!("UNRECOVERABLE ERROR: {:?}", error).bright_red();
+        error!("{}", message);
+    }
+
+    async fn periodic_report(&self) {
+        match self.metrics.last_seen_state_version {
+            Some(state_version) => {
+                let state_message = format!(
+                    "HANDLED UP TO: {} - {}",
+                    state_version,
+                    self.metrics.last_seen_timestamp
+                        .expect("When handling a transaction it should always have a timestamp")
+                        .format("%a %d-%m-%Y %H:%M")
+                ).bright_blue();
+
+                let transaction_amount = self
+                    .metrics
+                    .recent_transactions
+                    .iter()
+                    .filter(|(time, _)| {
+                        time > &(Instant::now()
+                            - Duration::from_secs(
+                                METRIC_CONSIDERATION_INTERVAL_S,
+                            ))
+                    })
+                    .count();
+                let transactions_per_second = transaction_amount
+                    / METRIC_CONSIDERATION_INTERVAL_S.min(
+                        self.metrics.time_started.elapsed().as_secs().max(1),
+                    ) as usize;
+                let transactions_per_second_message = format!(
+                    "PROCESSING ~{} TRANSACTIONS PER SECOND",
+                    transactions_per_second
+                )
+                .bright_blue();
+                let micros_per_transaction = self
+                    .metrics
+                    .recent_transactions
+                    .iter()
+                    .fold(Duration::from_secs(0), |acc, (_, duration)| {
+                        acc + *duration
+                    })
+                    / transaction_amount as u32;
+                let micros_per_transaction_message = format!(
+                    "AVERAGE TIME PER TRANSACTION: ~{:?}",
+                    micros_per_transaction
+                )
+                .bright_blue();
+                info!("{}", state_message);
+                info!("{}", transactions_per_second_message);
+                info!("{}", micros_per_transaction_message);
+            }
+            None => {
+                info!("{}", "NO TRANSACTIONS HANDLED YET".bright_blue());
+            }
+        }
+    }
+
+    fn periodic_report_interval(&self) -> Duration {
+        if let Some(interval) = self.custom_report_interval {
+            interval
+        } else {
+            Duration::from_secs(5)
+        }
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,2 +1,8 @@
+//! Re-exports proc macros for defining event and transaction handlers.
+//!
+//! These macros convert async functions with a correct signature
+//! into a struct that implements the [`EventHandler`] or [`TransactionHandler`]
+//! trait.
+
 pub use handler_macro::event_handler;
 pub use handler_macro::transaction_handler;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,8 @@
 //! Re-exports proc macros for defining event and transaction handlers.
 //!
 //! These macros convert async functions with a correct signature
-//! into a struct that implements the [`EventHandler`] or [`TransactionHandler`]
+//! into a struct that implements the [`EventHandler`][crate::event_handler::EventHandler]
+//! or [`TransactionHandler`][crate::transaction_handler::TransactionHandler]
 //! trait.
 
 pub use handler_macro::event_handler;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,17 +1,28 @@
+//!
+//! Contains canonical models for ledger events and transactions.
+//! These models are used by the [`TransactionStream`][crate::stream::TransactionStream]
+//! and [`TransactionStreamProcessor`][crate::processor::TransactionStreamProcessor]
+//! to abstract the source of transactions and events.
+//!
+//! When implementing a new transaction stream, you will typically
+//! convert the native representations of events and transactions
+//! into these generic models.
+
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 
 /// Generic struct for ledger events from a
 /// transaction stream. To implement a new transaction
-/// stream type, you would typically implement `Into<Event>`
+/// stream type, you would typically implement [`Into<Event>`]
 /// for the native event type of the transaction stream.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
     pub name: String,
     pub binary_sbor_data: Vec<u8>,
     pub emitter: EventEmitter,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EventEmitter {
     Method {
         entity_address: String,
@@ -36,9 +47,9 @@ impl EventEmitter {
 
 /// Generic struct for ledger transactions from a
 /// transaction stream. To implement a new transaction
-/// stream type, you would typically implement `Into<Transaction>`
+/// stream type, you would typically implement [`Into<Transaction>`]
 /// for the native transaction type of the transaction stream.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     pub intent_hash: String,
     pub state_version: u64,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -20,10 +20,6 @@ use async_trait::async_trait;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 
-// Default retry intervals for transactions and events.
-const TRANSACTION_RETRY_INTERVAL_MS: u64 = 10_000;
-const EVENT_RETRY_INTERVAL_MS: u64 = 10_000;
-
 /// The main struct that processes transactions from a [`TransactionStream`].
 /// It processes transactions by calling a [`TransactionHandler`] for each transaction
 /// that has at least one event with an [`EventHandler`][crate::event_handler::EventHandler] registered.
@@ -78,10 +74,8 @@ where
             handler_registry,
             transaction_handler: Box::new(DefaultTransactionHandler),
             state,
-            transaction_retry_delay: Duration::from_millis(
-                TRANSACTION_RETRY_INTERVAL_MS,
-            ),
-            event_retry_delay: Duration::from_millis(EVENT_RETRY_INTERVAL_MS),
+            transaction_retry_delay: Duration::from_secs(10),
+            event_retry_delay: Duration::from_secs(10),
             logger: Some(Arc::new(
                 RwLock::new(Box::<DefaultLogger>::default()),
             )),

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -18,21 +18,19 @@ use std::thread::sleep;
 /// using the `HandlerRegistry` and then call `run` to start
 /// processing transactions.
 #[allow(non_camel_case_types)]
-pub struct TransactionStreamProcessor<STREAM, STATE, TRANSACTION_CONTEXT>
+pub struct TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
     STATE: Clone,
 {
     pub transaction_stream: STREAM,
-    pub handler_registry: HandlerRegistry<STATE, TRANSACTION_CONTEXT>,
-    pub transaction_handler:
-        Box<dyn TransactionHandler<STATE, TRANSACTION_CONTEXT>>,
+    pub handler_registry: HandlerRegistry,
+    pub transaction_handler: Box<dyn TransactionHandler<STATE>>,
     pub state: STATE,
 }
 
 #[allow(non_camel_case_types)]
-impl<STREAM, STATE, TRANSACTION_CONTEXT>
-    TransactionStreamProcessor<STREAM, STATE, TRANSACTION_CONTEXT>
+impl<STREAM, STATE> TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
     STATE: Clone,
@@ -42,9 +40,8 @@ where
     /// and initial `STATE`.
     pub fn new(
         transaction_stream: STREAM,
-        handler_registry: HandlerRegistry<STATE, TRANSACTION_CONTEXT>,
-        transaction_handler: impl TransactionHandler<STATE, TRANSACTION_CONTEXT>
-            + 'static,
+        handler_registry: HandlerRegistry,
+        transaction_handler: impl TransactionHandler<STATE> + 'static,
         state: STATE,
     ) -> Self {
         TransactionStreamProcessor {
@@ -63,8 +60,7 @@ where
         // that have a handler registered.
         let handler_exists = transaction.events.iter().any(|event| {
             self.handler_registry
-                .get_handler(event.emitter.address(), &event.name)
-                .is_some()
+                .handler_exists(event.emitter.address(), &event.name)
         });
         if !handler_exists {
             // If there are no handlers for any of the events in this transaction,
@@ -184,9 +180,8 @@ where
     // Shorthand for running the processor with the required parameters.
     pub async fn run_with(
         transaction_stream: STREAM,
-        handler_registry: HandlerRegistry<STATE, TRANSACTION_CONTEXT>,
-        transaction_handler: impl TransactionHandler<STATE, TRANSACTION_CONTEXT>
-            + 'static,
+        handler_registry: HandlerRegistry,
+        transaction_handler: impl TransactionHandler<STATE> + 'static,
         state: STATE,
     ) -> Result<(), TransactionStreamProcessorError> {
         let mut processor = TransactionStreamProcessor::new(
@@ -209,7 +204,7 @@ where
     STREAM: TransactionStream,
     STATE: Clone,
 {
-    processor: TransactionStreamProcessor<STREAM, STATE, ()>,
+    processor: TransactionStreamProcessor<STREAM, STATE>,
 }
 
 #[allow(non_camel_case_types)]
@@ -220,10 +215,10 @@ where
 {
     pub fn new(
         transaction_stream: STREAM,
-        handler_registry: HandlerRegistry<STATE, ()>,
+        handler_registry: HandlerRegistry,
         state: STATE,
     ) -> Self {
-        let processor: TransactionStreamProcessor<STREAM, STATE, ()> =
+        let processor: TransactionStreamProcessor<STREAM, STATE> =
             TransactionStreamProcessor::new(
                 transaction_stream,
                 handler_registry,
@@ -239,7 +234,7 @@ where
 
     pub async fn run_with(
         transaction_stream: STREAM,
-        handler_registry: HandlerRegistry<STATE, ()>,
+        handler_registry: HandlerRegistry,
         state: STATE,
     ) -> Result<(), TransactionStreamProcessorError> {
         let mut processor = SimpleTransactionStreamProcessor::new(
@@ -257,17 +252,21 @@ where
 struct DefaultTransactionHandler;
 
 #[async_trait]
-impl<STATE> TransactionHandler<STATE, ()> for DefaultTransactionHandler
+impl<STATE> TransactionHandler<STATE> for DefaultTransactionHandler
 where
-    STATE: Clone + Send + Sync,
+    STATE: Clone + Send + Sync + 'static,
 {
     async fn handle(
         &self,
-        input: TransactionHandlerContext<'_, STATE, ()>,
+        input: TransactionHandlerContext<'_, STATE>,
     ) -> Result<(), TransactionHandlerError> {
         input
             .transaction
-            .process_events(input.state, input.handler_registry, &mut ())
+            .process_events::<STATE, ()>(
+                input.state,
+                input.handler_registry,
+                &mut (),
+            )
             .await
             .unwrap();
         Ok(())
@@ -286,10 +285,10 @@ impl Transaction {
     /// Please consider that event handlers may be called multiple times
     /// in this case, so they must be idempotent at least up to the point
     /// where the error occurred.
-    pub async fn process_events<STATE, TRANSACTION_CONTEXT>(
+    pub async fn process_events<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
         &self,
         state: &mut STATE,
-        handler_registry: &mut HandlerRegistry<STATE, TRANSACTION_CONTEXT>,
+        handler_registry: &mut HandlerRegistry,
         transaction_context: &mut TRANSACTION_CONTEXT,
     ) -> Result<(), EventHandlerError>
     where
@@ -297,13 +296,17 @@ impl Transaction {
     {
         for event in self.events.iter() {
             let event_handler = {
-                let handler = match handler_registry
-                    .get_handler(event.emitter.address(), &event.name)
+                if !handler_registry
+                    .handler_exists(event.emitter.address(), &event.name)
                 {
-                    Some(handler) => handler,
-                    None => continue,
-                };
-                handler
+                    continue;
+                }
+                handler_registry
+                    .get_handler::<STATE, TRANSACTION_CONTEXT>(
+                        event.emitter.address(),
+                        &event.name,
+                    )
+                    .unwrap()
             };
             let event_handler = event_handler.clone();
             info!(

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,184 +1,73 @@
+/*!
+# Transaction Stream Processor - Ties everything together and does the heavy lifting
+
+This module holds the main struct that processes transactions from a [`TransactionStream`],
+a default implementation of a [`TransactionHandler`], and a struct that processes events in a [`TransactionHandler`].
+*/
+
 use crate::{
     error::{
         EventHandlerError, TransactionHandlerError,
         TransactionStreamProcessorError,
     },
-    event_handler::{EventHandlerContext, HandlerRegistry},
-    models::{Event, Transaction},
+    event_handler::{EventHandlerContext, HandlerRegistry, State},
+    logger::{DefaultLogger, Logger},
+    models::Transaction,
     stream::TransactionStream,
     transaction_handler::{TransactionHandler, TransactionHandlerContext},
 };
 use async_trait::async_trait;
-use colored::Colorize;
-use log::{error, info, Log};
-use std::{
-    sync::{Arc, RwLock},
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::RwLock;
 
-const CURRENT_STATE_REPORT_INTERVAL: u64 = 60;
-const TRANSACTION_RETRY_INTERVAL: u64 = 10;
-const EVENT_RETRY_INTERVAL: u64 = 10;
+// Default retry intervals for transactions and events.
+const TRANSACTION_RETRY_INTERVAL_MS: u64 = 10_000;
+const EVENT_RETRY_INTERVAL_MS: u64 = 10_000;
 
-pub trait Logger: Send + Sync {
-    fn before_handle_transaction(&self, transaction: &Transaction);
-    fn after_handle_transaction(
-        &self,
-        transaction: &Transaction,
-        time_spent: Duration,
-    );
-    fn before_handle_event(&self, transaction: &Transaction, event: &Event);
-    fn after_handle_event(
-        &self,
-        transaction: &Transaction,
-        event: &Event,
-        time_spent: Duration,
-    );
-    fn event_retry_error(
-        &self,
-        transaction: &Transaction,
-        event: &Event,
-        error: &anyhow::Error,
-        timeout: Duration,
-    );
-    fn transaction_retry_error(
-        &self,
-        transaction: &Transaction,
-        error: &anyhow::Error,
-        timeout: Duration,
-    );
-    fn unrecoverable_error(&self, error: &anyhow::Error);
-}
-
-pub struct DefaultLogger;
-
-impl Logger for DefaultLogger {
-    fn before_handle_transaction(&self, transaction: &Transaction) {
-        info!(
-            "{}",
-            "--------------------------------------------------------"
-                .bright_blue()
-        );
-        info!(
-            "{}",
-            format!(
-                "HANDLING TRANSACTION - {:#?} - {}",
-                transaction.state_version,
-                transaction.confirmed_at
-                    .expect("When handling a transaction it should always have a timestamp")
-                    .format("%a %d-%m-%Y %H:%M")
-            )
-            .bright_green()
-        );
-    }
-
-    fn after_handle_transaction(
-        &self,
-        transaction: &Transaction,
-        time_spent: Duration,
-    ) {
-        info!(
-            "{}",
-            format!(
-                "###### END TRANSACTION - HANDLED IN {}ms ######",
-                time_spent.as_millis()
-            )
-            .bright_green()
-        );
-        info!(
-            "{}",
-            "--------------------------------------------------------"
-                .bright_blue()
-        );
-    }
-
-    fn before_handle_event(&self, transaction: &Transaction, event: &Event) {
-        info!(
-            "{}",
-            format!("HANDLING EVENT: {}", event.name).bright_yellow()
-        );
-    }
-
-    fn after_handle_event(
-        &self,
-        transaction: &Transaction,
-        event: &Event,
-        time_spent: Duration,
-    ) {
-    }
-
-    fn event_retry_error(
-        &self,
-        transaction: &Transaction,
-        event: &Event,
-        error: &anyhow::Error,
-        timeout: Duration,
-    ) {
-        error!(
-            "{}",
-            format!("ERROR HANDLING EVENT: {} - {:?}", event.name, error)
-                .bright_red()
-        );
-        info!(
-            "{}",
-            format!("RETRYING IN {:.2} SECONDS\n", timeout.as_secs_f32())
-                .bright_yellow()
-        );
-    }
-
-    fn transaction_retry_error(
-        &self,
-        transaction: &Transaction,
-        error: &anyhow::Error,
-        timeout: Duration,
-    ) {
-        error!(
-            "{}",
-            format!("FATAL ERROR HANDLING TRANSACTION: {:?}\n", error)
-                .bright_red()
-        );
-        info!(
-            "{}",
-            format!("RETRYING IN {:.2} SECONDS\n", timeout.as_secs_f32())
-                .bright_yellow()
-        );
-    }
-
-    fn unrecoverable_error(&self, error: &anyhow::Error) {
-        error!(
-            "{}",
-            format!("UNRECOVERABLE ERROR: {:?}", error).bright_red()
-        );
-    }
-}
-
-/// Uses a `TransactionStream` to procoess transactions and
-/// events using a `HandlerRegistry`. Register event handlers
-/// using the `HandlerRegistry` and then call `run` to start
-/// processing transactions.
+/// The main struct that processes transactions from a [`TransactionStream`].
+/// It processes transactions by calling a [`TransactionHandler`] for each transaction
+/// that has at least one event with an [`EventHandler`][crate::event_handler::EventHandler] registered.
+/// It can be created using a builder pattern, where you can set the [`TransactionHandler`],
+/// retry intervals, and logger.
+///
+/// If you don't set a transaction handler explicitly, the processor will use a default handler
+/// that simply calls [`EventProcessor::process_events`] on the transaction, without any custom logic.
 #[allow(non_camel_case_types)]
 pub struct TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
+    STATE: State,
 {
     transaction_stream: STREAM,
     handler_registry: HandlerRegistry,
     transaction_handler: Box<dyn TransactionHandler<STATE>>,
     state: STATE,
-    state_version_last_reported: Instant,
     transaction_retry_delay: Duration,
     event_retry_delay: Duration,
-    current_state_report_interval: Duration,
-    current_state: Arc<RwLock<Option<u64>>>,
-    logger: Option<Box<dyn Logger>>,
+    logger: Option<Arc<RwLock<Box<dyn Logger>>>>,
+    periodic_logging_joinhandle: Option<tokio::task::JoinHandle<()>>,
 }
 
 #[allow(non_camel_case_types)]
 impl<STREAM, STATE> TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
-    STATE: Send + Sync + 'static,
+    STATE: State,
 {
+    /// Creates a new [`TransactionStreamProcessor`] with the given
+    /// [`TransactionStream`], [`HandlerRegistry`], and `STATE`.
+    ///
+    /// - The [`TransactionHandler`] is set to a default handler that
+    /// simply calls [`EventProcessor::process_events`] on the transaction, without
+    /// any custom logic.
+    ///
+    /// - The default retry intervals for transactions and events are
+    /// set to 10 seconds.
+    ///
+    /// - The logger is set to a default logger that logs to stdout.
+    ///
+    /// Change the default handler, retry intervals, or logger using
+    /// the builder methods.
     pub fn new(
         transaction_stream: STREAM,
         handler_registry: HandlerRegistry,
@@ -187,24 +76,25 @@ where
         TransactionStreamProcessor {
             transaction_stream,
             handler_registry,
-            transaction_handler: Box::new(DefaultTransactionHandler {}),
-            state_version_last_reported: Instant::now(),
+            transaction_handler: Box::new(DefaultTransactionHandler),
             state: state,
             transaction_retry_delay: Duration::from_millis(
-                TRANSACTION_RETRY_INTERVAL,
+                TRANSACTION_RETRY_INTERVAL_MS,
             ),
-            event_retry_delay: Duration::from_millis(EVENT_RETRY_INTERVAL),
-            current_state_report_interval: Duration::from_millis(
-                CURRENT_STATE_REPORT_INTERVAL,
-            ),
-            current_state: Arc::new(RwLock::new(None)),
-            logger: None,
+            event_retry_delay: Duration::from_millis(EVENT_RETRY_INTERVAL_MS),
+            logger: Some(Arc::new(RwLock::new(Box::new(
+                DefaultLogger::default(),
+            )))),
+            periodic_logging_joinhandle: None,
         }
     }
 
+    /// Sets the [`TransactionHandler`] for the processor.
+    /// This handler is called for each transaction that has at least one event which
+    /// has event handlers registered.
     pub fn transaction_handler(
         self,
-        transaction_handler: impl TransactionHandler<STATE> + 'static,
+        transaction_handler: impl TransactionHandler<STATE>,
     ) -> Self {
         TransactionStreamProcessor {
             transaction_handler: Box::new(transaction_handler),
@@ -212,56 +102,86 @@ where
         }
     }
 
-    pub fn transaction_retry_delay_ms(
+    /// Sets the retry delay for transactions that fail to process and return a `TransactionRetryError`
+    /// (see [`crate::error::TransactionHandlerError`]).
+    pub fn transaction_retry_delay(
         self,
-        transaction_retry_delay_ms: u64,
+        transaction_retry_delay: Duration,
     ) -> Self {
         TransactionStreamProcessor {
-            transaction_retry_delay: Duration::from_millis(
-                transaction_retry_delay_ms,
-            ),
+            transaction_retry_delay,
             ..self
         }
     }
 
-    pub fn event_retry_delay_ms(self, event_retry_delay_ms: u64) -> Self {
+    /// Sets the retry delay for events that fail to process and return an `EventRetryError`.
+    /// (see [`crate::error::EventHandlerError`]).
+    pub fn event_retry_delay(self, event_retry_delay: Duration) -> Self {
         TransactionStreamProcessor {
-            event_retry_delay: Duration::from_millis(event_retry_delay_ms),
+            event_retry_delay,
             ..self
         }
     }
 
-    pub fn current_state_report_interval_ms(
+    /// Sets the logger for the processor. It should implement the [`Logger`] trait.
+    pub fn logger(self, logger: impl Logger + 'static) -> Self {
+        TransactionStreamProcessor {
+            logger: Some(Arc::new(RwLock::new(Box::new(logger)))),
+            ..self
+        }
+    }
+
+    /// Sets the logger for the processor to the default logger, but with
+    /// a custom report interval given by `interval`.
+    pub fn default_logger_with_report_interval(
         self,
-        current_state_report_interval_ms: u64,
+        interval: Duration,
     ) -> Self {
         TransactionStreamProcessor {
-            current_state_report_interval: Duration::from_millis(
-                current_state_report_interval_ms,
-            ),
+            logger: Some(Arc::new(RwLock::new(Box::new(
+                DefaultLogger::with_custom_report_interval(interval),
+            )))),
             ..self
         }
     }
 
+    /// Disables logging for the processor by setting the logger to `None`.
+    pub fn disable_logging(self) -> Self {
+        TransactionStreamProcessor {
+            logger: None,
+            ..self
+        }
+    }
+
+    /// Processes a single transaction.
+    ///
+    /// Returns:
+    /// - `Ok(true)` if the transaction was processed successfully,
+    /// - `Ok(false)` if the transaction was skipped because it had no handlers,
+    /// - `Err(TransactionStreamProcessorError)` if an unrecoverable error occurred somewhere in a handler.
     pub async fn process_transaction(
         &mut self,
         transaction: &Transaction,
-    ) -> Result<(), TransactionStreamProcessorError> {
-        let before = Instant::now();
+    ) -> Result<bool, TransactionStreamProcessorError> {
         // Find out if there are any events inside this transaction
         // that have a handler registered.
         let handler_exists = transaction.events.iter().any(|event| {
             self.handler_registry
                 .handler_exists(event.emitter.address(), &event.name)
         });
+
+        if let Some(logger) = &self.logger {
+            logger
+                .write()
+                .await
+                .receive_transaction(transaction, handler_exists, false)
+                .await;
+        }
+
         if !handler_exists {
             // If there are no handlers for any of the events in this transaction,
             // we can skip processing it.
-            return Ok(());
-        }
-
-        if let Some(logger) = &self.logger {
-            logger.before_handle_transaction(transaction);
+            return Ok(false);
         }
 
         // Keep trying to handle the transaction in case
@@ -283,21 +203,33 @@ where
             match err {
                 TransactionHandlerError::TransactionRetryError(e) => {
                     if let Some(logger) = &self.logger {
-                        logger.transaction_retry_error(
-                            transaction,
-                            &e,
-                            self.transaction_retry_delay,
-                        );
+                        logger
+                            .write()
+                            .await
+                            .transaction_retry_error(
+                                transaction,
+                                &e,
+                                self.transaction_retry_delay,
+                            )
+                            .await;
                     }
                     tokio::time::sleep(self.transaction_retry_delay).await;
                     if let Some(logger) = &self.logger {
-                        logger.before_handle_transaction(transaction);
+                        logger
+                            .write()
+                            .await
+                            .receive_transaction(
+                                transaction,
+                                handler_exists,
+                                true,
+                            )
+                            .await;
                     }
                     continue;
                 }
                 TransactionHandlerError::UnrecoverableError(e) => {
                     if let Some(logger) = &self.logger {
-                        logger.unrecoverable_error(&e);
+                        logger.write().await.unrecoverable_error(&e).await;
                     }
                     return Err(
                         TransactionStreamProcessorError::UnrecoverableError(e),
@@ -305,17 +237,11 @@ where
                 }
             }
         }
-        if let Some(logger) = &self.logger {
-            logger.after_handle_transaction(transaction, before.elapsed());
-        }
-        self.current_state
-            .write()
-            .expect("Should be able to write the current state")
-            .replace(transaction.state_version);
-        Ok(())
+
+        Ok(true)
     }
 
-    /// Starts processing transactions from the `TransactionStream`.
+    /// Starts processing transactions from the [`TransactionStream`].
     pub async fn run(&mut self) -> Result<(), TransactionStreamProcessorError> {
         // Start the transaction stream and get a receiver.
         // This often involves starting a task that fetches transactions
@@ -324,34 +250,40 @@ where
             self.transaction_stream.start().await.map_err(|error| {
                 TransactionStreamProcessorError::UnrecoverableError(error)
             })?;
+        let logger = self.logger.clone();
+        self.periodic_logging_joinhandle = if let Some(logger) = logger {
+            let interval = logger.read().await.periodic_report_interval();
+            Some(tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(interval).await;
+                    logger.read().await.periodic_report().await;
+                }
+            }))
+        } else {
+            None
+        };
         // Process transactions as they arrive.
         while let Some(transaction) = receiver.recv().await {
-            if self.state_version_last_reported.elapsed()
-                > self.current_state_report_interval
-            {
-                info!(
-                    "{}",
-                    format!(
-                        "HANDLED UP TO: {} - {}",
-                        transaction.state_version,
-                        transaction.confirmed_at
-                            .expect("When handling a transaction it should always have a timestamp")
-                            .format("%a %d-%m-%Y %H:%M")
-                    )
-                    .bright_blue()
-                );
-                self.state_version_last_reported = Instant::now();
+            let handled = self.process_transaction(&transaction).await?;
+            if let Some(logger) = &self.logger {
+                logger
+                    .write()
+                    .await
+                    .finish_transaction(&transaction, handled)
+                    .await;
             }
-            self.process_transaction(&transaction).await?;
         }
         // If the transmitting half of the channel is dropped,
         // the receiver will return None and we will exit the loop.
         // The processor will exit gracefully.
+        if let Some(handle) = self.periodic_logging_joinhandle.take() {
+            handle.abort();
+        }
         Ok(())
     }
 }
 
-/// A default transaction handler that simply calls `process_events`
+/// A default transaction handler that simply calls [`EventProcessor::process_events`]
 /// on the transaction, without any custom logic.
 #[derive(Clone)]
 struct DefaultTransactionHandler;
@@ -359,7 +291,7 @@ struct DefaultTransactionHandler;
 #[async_trait]
 impl<STATE> TransactionHandler<STATE> for DefaultTransactionHandler
 where
-    STATE: Send + Sync + 'static,
+    STATE: State,
 {
     async fn handle(
         &self,
@@ -373,30 +305,44 @@ where
     }
 }
 
+/// The [`EventProcessor`]'s only purpose is to have a convenience method to process events in a transaction.
+/// The user calls [`EventProcessor::process_events`] when implementing a custom [`TransactionHandler`].
+/// It will iterate over the events in the transaction and call the appropriate event handlers.
+/// It handles retries for events that fail to process, and calls logging hooks.
+/// It is highly recommended to use this method when implementing a custom [`TransactionHandler`].
 pub struct EventProcessor<'a> {
     event_retry_interval: Duration,
     transaction: &'a Transaction,
-    logger: &'a Option<Box<dyn Logger>>,
+    logger: &'a Option<Arc<RwLock<Box<dyn Logger>>>>,
 }
 
 #[allow(non_camel_case_types)]
 impl<'a> EventProcessor<'a> {
-    pub async fn process_events<
-        STATE: 'static,
-        TRANSACTION_CONTEXT: 'static,
-    >(
+    pub async fn process_events<STATE: State, TRANSACTION_CONTEXT: 'static>(
         &self,
         state: &mut STATE,
         handler_registry: &mut HandlerRegistry,
         transaction_context: &mut TRANSACTION_CONTEXT,
     ) -> Result<(), EventHandlerError> {
         for event in self.transaction.events.iter() {
+            let handler_exists = handler_registry
+                .handler_exists(event.emitter.address(), &event.name);
+            if !handler_exists {
+                continue;
+            }
+            if let Some(logger) = self.logger {
+                logger
+                    .write()
+                    .await
+                    .receive_event(
+                        self.transaction,
+                        event,
+                        handler_exists,
+                        false,
+                    )
+                    .await;
+            }
             let event_handler = {
-                if !handler_registry
-                    .handler_exists(event.emitter.address(), &event.name)
-                {
-                    continue;
-                }
                 handler_registry
                     .get_handler::<STATE, TRANSACTION_CONTEXT>(
                         event.emitter.address(),
@@ -405,11 +351,6 @@ impl<'a> EventProcessor<'a> {
                     .unwrap()
             };
             let event_handler = event_handler.clone();
-            let mut before: Option<Instant> = None;
-            if let Some(logger) = self.logger {
-                before = Some(Instant::now());
-                logger.before_handle_event(self.transaction, event);
-            }
             while let Err(err) = event_handler
                 .handle(
                     EventHandlerContext {
@@ -419,23 +360,36 @@ impl<'a> EventProcessor<'a> {
                         handler_registry,
                         transaction_context,
                     },
-                    event.binary_sbor_data.clone(),
+                    &event.binary_sbor_data,
                 )
                 .await
             {
                 match err {
                     EventHandlerError::EventRetryError(e) => {
                         if let Some(logger) = self.logger {
-                            logger.event_retry_error(
-                                self.transaction,
-                                event,
-                                &e,
-                                self.event_retry_interval,
-                            );
+                            logger
+                                .write()
+                                .await
+                                .event_retry_error(
+                                    self.transaction,
+                                    event,
+                                    &e,
+                                    self.event_retry_interval,
+                                )
+                                .await;
                         }
                         tokio::time::sleep(self.event_retry_interval).await;
                         if let Some(logger) = self.logger {
-                            logger.before_handle_event(self.transaction, event);
+                            logger
+                                .write()
+                                .await
+                                .receive_event(
+                                    self.transaction,
+                                    event,
+                                    handler_exists,
+                                    true,
+                                )
+                                .await;
                         }
                         continue;
                     }
@@ -445,11 +399,11 @@ impl<'a> EventProcessor<'a> {
                 }
             }
             if let Some(logger) = self.logger {
-                logger.after_handle_event(
-                    self.transaction,
-                    event,
-                    before.unwrap().elapsed(),
-                );
+                logger
+                    .write()
+                    .await
+                    .finish_event(self.transaction, event, handler_exists)
+                    .await;
             }
         }
         Ok(())

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -4,20 +4,155 @@ use crate::{
         TransactionStreamProcessorError,
     },
     event_handler::{EventHandlerContext, HandlerRegistry},
-    models::Transaction,
+    models::{Event, Transaction},
     stream::TransactionStream,
     transaction_handler::{TransactionHandler, TransactionHandlerContext},
 };
 use async_trait::async_trait;
 use colored::Colorize;
-use log::{error, info};
-use std::time::{Duration, Instant};
+use log::{error, info, Log};
+use std::{
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 
 const CURRENT_STATE_REPORT_INTERVAL: u64 = 60;
 const TRANSACTION_RETRY_INTERVAL: u64 = 10;
 const EVENT_RETRY_INTERVAL: u64 = 10;
 
-/// Uses a `TransactionStream` to process transactions and
+pub trait Logger: Send + Sync {
+    fn before_handle_transaction(&self, transaction: &Transaction);
+    fn after_handle_transaction(
+        &self,
+        transaction: &Transaction,
+        time_spent: Duration,
+    );
+    fn before_handle_event(&self, transaction: &Transaction, event: &Event);
+    fn after_handle_event(
+        &self,
+        transaction: &Transaction,
+        event: &Event,
+        time_spent: Duration,
+    );
+    fn event_retry_error(
+        &self,
+        transaction: &Transaction,
+        event: &Event,
+        error: &anyhow::Error,
+        timeout: Duration,
+    );
+    fn transaction_retry_error(
+        &self,
+        transaction: &Transaction,
+        error: &anyhow::Error,
+        timeout: Duration,
+    );
+    fn unrecoverable_error(&self, error: &anyhow::Error);
+}
+
+pub struct DefaultLogger;
+
+impl Logger for DefaultLogger {
+    fn before_handle_transaction(&self, transaction: &Transaction) {
+        info!(
+            "{}",
+            "--------------------------------------------------------"
+                .bright_blue()
+        );
+        info!(
+            "{}",
+            format!(
+                "HANDLING TRANSACTION - {:#?} - {}",
+                transaction.state_version,
+                transaction.confirmed_at
+                    .expect("When handling a transaction it should always have a timestamp")
+                    .format("%a %d-%m-%Y %H:%M")
+            )
+            .bright_green()
+        );
+    }
+
+    fn after_handle_transaction(
+        &self,
+        transaction: &Transaction,
+        time_spent: Duration,
+    ) {
+        info!(
+            "{}",
+            format!(
+                "###### END TRANSACTION - HANDLED IN {}ms ######",
+                time_spent.as_millis()
+            )
+            .bright_green()
+        );
+        info!(
+            "{}",
+            "--------------------------------------------------------"
+                .bright_blue()
+        );
+    }
+
+    fn before_handle_event(&self, transaction: &Transaction, event: &Event) {
+        info!(
+            "{}",
+            format!("HANDLING EVENT: {}", event.name).bright_yellow()
+        );
+    }
+
+    fn after_handle_event(
+        &self,
+        transaction: &Transaction,
+        event: &Event,
+        time_spent: Duration,
+    ) {
+    }
+
+    fn event_retry_error(
+        &self,
+        transaction: &Transaction,
+        event: &Event,
+        error: &anyhow::Error,
+        timeout: Duration,
+    ) {
+        error!(
+            "{}",
+            format!("ERROR HANDLING EVENT: {} - {:?}", event.name, error)
+                .bright_red()
+        );
+        info!(
+            "{}",
+            format!("RETRYING IN {:.2} SECONDS\n", timeout.as_secs_f32())
+                .bright_yellow()
+        );
+    }
+
+    fn transaction_retry_error(
+        &self,
+        transaction: &Transaction,
+        error: &anyhow::Error,
+        timeout: Duration,
+    ) {
+        error!(
+            "{}",
+            format!("FATAL ERROR HANDLING TRANSACTION: {:?}\n", error)
+                .bright_red()
+        );
+        info!(
+            "{}",
+            format!("RETRYING IN {:.2} SECONDS\n", timeout.as_secs_f32())
+                .bright_yellow()
+        );
+    }
+
+    fn unrecoverable_error(&self, error: &anyhow::Error) {
+        error!(
+            "{}",
+            format!("UNRECOVERABLE ERROR: {:?}", error).bright_red()
+        );
+    }
+}
+
+/// Uses a `TransactionStream` to procoess transactions and
 /// events using a `HandlerRegistry`. Register event handlers
 /// using the `HandlerRegistry` and then call `run` to start
 /// processing transactions.
@@ -34,6 +169,8 @@ where
     transaction_retry_delay: Duration,
     event_retry_delay: Duration,
     current_state_report_interval: Duration,
+    current_state: Arc<RwLock<Option<u64>>>,
+    logger: Option<Box<dyn Logger>>,
 }
 
 #[allow(non_camel_case_types)]
@@ -60,6 +197,8 @@ where
             current_state_report_interval: Duration::from_millis(
                 CURRENT_STATE_REPORT_INTERVAL,
             ),
+            current_state: Arc::new(RwLock::new(None)),
+            logger: None,
         }
     }
 
@@ -120,22 +259,10 @@ where
             // we can skip processing it.
             return Ok(());
         }
-        info!(
-            "{}",
-            "--------------------------------------------------------"
-                .bright_blue()
-        );
-        info!(
-            "{}",
-            format!(
-                "HANDLING TRANSACTION - {:#?} - {}",
-                transaction.state_version,
-                transaction.confirmed_at
-                    .expect("When handling a transaction it should always have a timestamp")
-                    .format("%a %d-%m-%Y %H:%M")
-            )
-            .bright_green()
-        );
+
+        if let Some(logger) = &self.logger {
+            logger.before_handle_transaction(transaction);
+        }
 
         // Keep trying to handle the transaction in case
         // the handler requests this through a TransactionHandlerError.
@@ -147,6 +274,7 @@ where
                 event_processor: &mut EventProcessor {
                     event_retry_interval: self.event_retry_delay,
                     transaction,
+                    logger: &self.logger,
                 },
                 handler_registry: &mut self.handler_registry,
             })
@@ -154,60 +282,36 @@ where
         {
             match err {
                 TransactionHandlerError::TransactionRetryError(e) => {
-                    error!(
-                        "{}",
-                        format!("ERROR HANDLING TRANSACTION: {}", e)
-                            .bright_red()
-                    );
-                    info!(
-                        "{}",
-                        format!(
-                            "RETRYING TRANSACTION IN {:.2} SECONDS\n",
-                            self.transaction_retry_delay.as_secs_f32()
-                        )
-                        .bright_yellow()
-                    );
+                    if let Some(logger) = &self.logger {
+                        logger.transaction_retry_error(
+                            transaction,
+                            &e,
+                            self.transaction_retry_delay,
+                        );
+                    }
                     tokio::time::sleep(self.transaction_retry_delay).await;
-                    info!(
-                        "{}",
-                        format!(
-                            "RETRYING TRANSACTION - {:#?} - {}",
-                            transaction.state_version,
-                            transaction.confirmed_at
-                                .expect("When handling a transaction it should always have a timestamp")
-                                .to_rfc3339()
-                        )
-                        .bright_yellow()
-                    );
+                    if let Some(logger) = &self.logger {
+                        logger.before_handle_transaction(transaction);
+                    }
                     continue;
                 }
-                TransactionHandlerError::UnrecoverableError(err) => {
-                    error!(
-                        "{}",
-                        format!("FATAL ERROR HANDLING TRANSACTION: {}\n", err)
-                            .bright_red()
-                    );
+                TransactionHandlerError::UnrecoverableError(e) => {
+                    if let Some(logger) = &self.logger {
+                        logger.unrecoverable_error(&e);
+                    }
                     return Err(
-                        TransactionStreamProcessorError::UnrecoverableError(
-                            err,
-                        ),
+                        TransactionStreamProcessorError::UnrecoverableError(e),
                     );
                 }
             }
         }
-        info!(
-            "{}",
-            format!(
-                "###### END TRANSACTION - HANDLED IN {}ms ######",
-                before.elapsed().as_millis()
-            )
-            .bright_green()
-        );
-        info!(
-            "{}",
-            "--------------------------------------------------------"
-                .bright_blue()
-        );
+        if let Some(logger) = &self.logger {
+            logger.after_handle_transaction(transaction, before.elapsed());
+        }
+        self.current_state
+            .write()
+            .expect("Should be able to write the current state")
+            .replace(transaction.state_version);
         Ok(())
     }
 
@@ -272,6 +376,7 @@ where
 pub struct EventProcessor<'a> {
     event_retry_interval: Duration,
     transaction: &'a Transaction,
+    logger: &'a Option<Box<dyn Logger>>,
 }
 
 #[allow(non_camel_case_types)]
@@ -300,10 +405,11 @@ impl<'a> EventProcessor<'a> {
                     .unwrap()
             };
             let event_handler = event_handler.clone();
-            info!(
-                "{}",
-                format!("HANDLING EVENT: {}", event.name).bright_yellow()
-            );
+            let mut before: Option<Instant> = None;
+            if let Some(logger) = self.logger {
+                before = Some(Instant::now());
+                logger.before_handle_event(self.transaction, event);
+            }
             while let Err(err) = event_handler
                 .handle(
                     EventHandlerContext {
@@ -319,31 +425,31 @@ impl<'a> EventProcessor<'a> {
             {
                 match err {
                     EventHandlerError::EventRetryError(e) => {
-                        error!(
-                            "{}",
-                            format!("ERROR HANDLING EVENT: {}", e).bright_red()
-                        );
-
-                        info!(
-                            "{}",
-                            format!(
-                                "RETRYING IN {:.2} SECONDS\n",
-                                self.event_retry_interval.as_secs_f32()
-                            )
-                            .bright_yellow()
-                        );
+                        if let Some(logger) = self.logger {
+                            logger.event_retry_error(
+                                self.transaction,
+                                event,
+                                &e,
+                                self.event_retry_interval,
+                            );
+                        }
                         tokio::time::sleep(self.event_retry_interval).await;
-                        info!(
-                            "{}",
-                            format!("RETRYING HANDLING EVENT: {}", event.name)
-                                .bright_yellow()
-                        );
+                        if let Some(logger) = self.logger {
+                            logger.before_handle_event(self.transaction, event);
+                        }
                         continue;
                     }
                     _ => {
                         return Err(err);
                     }
                 }
+            }
+            if let Some(logger) = self.logger {
+                logger.after_handle_event(
+                    self.transaction,
+                    event,
+                    before.unwrap().elapsed(),
+                );
             }
         }
         Ok(())

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -276,6 +276,7 @@ where
         // If the transmitting half of the channel is dropped,
         // the receiver will return None and we will exit the loop.
         // The processor will exit gracefully.
+
         if let Some(handle) = self.periodic_logging_joinhandle.take() {
             handle.abort();
         }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -73,7 +73,7 @@ where
         handler_registry: HandlerRegistry,
         state: STATE,
     ) -> Self {
-        TransactionStreamProcessor {
+        Self {
             transaction_stream,
             handler_registry,
             transaction_handler: Box::new(DefaultTransactionHandler),
@@ -96,7 +96,7 @@ where
         self,
         transaction_handler: impl TransactionHandler<STATE>,
     ) -> Self {
-        TransactionStreamProcessor {
+        Self {
             transaction_handler: Box::new(transaction_handler),
             ..self
         }
@@ -108,7 +108,7 @@ where
         self,
         transaction_retry_delay: Duration,
     ) -> Self {
-        TransactionStreamProcessor {
+        Self {
             transaction_retry_delay,
             ..self
         }
@@ -117,7 +117,7 @@ where
     /// Sets the retry delay for events that fail to process and return an `EventRetryError`.
     /// (see [`crate::error::EventHandlerError`]).
     pub fn event_retry_delay(self, event_retry_delay: Duration) -> Self {
-        TransactionStreamProcessor {
+        Self {
             event_retry_delay,
             ..self
         }
@@ -125,7 +125,7 @@ where
 
     /// Sets the logger for the processor. It should implement the [`Logger`] trait.
     pub fn logger(self, logger: impl Logger + 'static) -> Self {
-        TransactionStreamProcessor {
+        Self {
             logger: Some(Arc::new(RwLock::new(Box::new(logger)))),
             ..self
         }
@@ -137,7 +137,7 @@ where
         self,
         interval: Duration,
     ) -> Self {
-        TransactionStreamProcessor {
+        Self {
             logger: Some(Arc::new(RwLock::new(Box::new(
                 DefaultLogger::with_custom_report_interval(interval),
             )))),
@@ -147,7 +147,7 @@ where
 
     /// Disables logging for the processor by setting the logger to `None`.
     pub fn disable_logging(self) -> Self {
-        TransactionStreamProcessor {
+        Self {
             logger: None,
             ..self
         }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -90,7 +90,7 @@ where
         );
 
         // Keep trying to handle the transaction in case
-        // the user requests this through a TransactionHandlerError.
+        // the handler requests this through a TransactionHandlerError.
         while let Err(err) = self
             .transaction_handler
             .handle(TransactionHandlerContext {
@@ -116,16 +116,16 @@ where
                         TRANSACTION_RETRY_INTERVAL,
                     ));
                     info!(
-                                "{}",
-                                format!(
-                                    "RETRYING TRANSACTION - {:#?} - {}",
-                                    transaction.state_version,
-                                    transaction.confirmed_at
-                                        .expect("When handling a transaction it should always have a timestamp")
-                                        .to_rfc3339()
-                                )
-                                .bright_yellow()
-                            );
+                        "{}",
+                        format!(
+                            "RETRYING TRANSACTION - {:#?} - {}",
+                            transaction.state_version,
+                            transaction.confirmed_at
+                                .expect("When handling a transaction it should always have a timestamp")
+                                .to_rfc3339()
+                        )
+                        .bright_yellow()
+                    );
                     continue;
                 }
                 TransactionHandlerError::UnrecoverableError(err) => {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -57,7 +57,7 @@ where
                 TRANSACTION_RETRY_INTERVAL,
             ),
             event_retry_delay: Duration::from_millis(EVENT_RETRY_INTERVAL),
-            current_state_report_interval: Duration::from_secs(
+            current_state_report_interval: Duration::from_millis(
                 CURRENT_STATE_REPORT_INTERVAL,
             ),
         }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -77,14 +77,14 @@ where
             transaction_stream,
             handler_registry,
             transaction_handler: Box::new(DefaultTransactionHandler),
-            state: state,
+            state,
             transaction_retry_delay: Duration::from_millis(
                 TRANSACTION_RETRY_INTERVAL_MS,
             ),
             event_retry_delay: Duration::from_millis(EVENT_RETRY_INTERVAL_MS),
-            logger: Some(Arc::new(RwLock::new(Box::new(
-                DefaultLogger::default(),
-            )))),
+            logger: Some(Arc::new(
+                RwLock::new(Box::<DefaultLogger>::default()),
+            )),
             periodic_logging_joinhandle: None,
         }
     }
@@ -355,7 +355,7 @@ impl<'a> EventProcessor<'a> {
             while let Err(err) = event_handler
                 .handle(
                     EventHandlerContext {
-                        state: state,
+                        state,
                         transaction: self.transaction,
                         event,
                         handler_registry,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -65,6 +65,7 @@ where
         &mut self,
         transaction: &Transaction,
     ) -> Result<(), TransactionStreamProcessorError> {
+        let before = Instant::now();
         // Find out if there are any events inside this transaction
         // that have a handler registered.
         let handler_exists = transaction.events.iter().any(|event| {
@@ -147,7 +148,14 @@ where
                 }
             }
         }
-        info!("{}", "###### END TRANSACTION ######".bright_green());
+        info!(
+            "{}",
+            format!(
+                "###### END TRANSACTION - HANDLED IN {}ms ######",
+                before.elapsed().as_millis()
+            )
+            .bright_green()
+        );
         info!(
             "{}",
             "--------------------------------------------------------"

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -25,7 +25,6 @@ const EVENT_RETRY_INTERVAL: u64 = 10;
 pub struct TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
-    STATE: Clone,
 {
     pub transaction_stream: STREAM,
     pub handler_registry: HandlerRegistry,
@@ -38,7 +37,6 @@ where
 impl<STREAM, STATE> TransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
-    STATE: Clone,
 {
     /// Creates a new `TransactionStreamProcessor` with the given
     /// `TransactionStream`, `HandlerRegistry`, `TransactionHandler`
@@ -220,7 +218,6 @@ where
 pub struct SimpleTransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
-    STATE: Clone,
 {
     processor: TransactionStreamProcessor<STREAM, STATE>,
 }
@@ -229,7 +226,7 @@ where
 impl<STREAM, STATE> SimpleTransactionStreamProcessor<STREAM, STATE>
 where
     STREAM: TransactionStream,
-    STATE: Clone + 'static + Send + Sync,
+    STATE: 'static + Send + Sync,
 {
     pub fn new(
         transaction_stream: STREAM,
@@ -272,7 +269,7 @@ struct DefaultTransactionHandler;
 #[async_trait]
 impl<STATE> TransactionHandler<STATE> for DefaultTransactionHandler
 where
-    STATE: Clone + Send + Sync + 'static,
+    STATE: Send + Sync + 'static,
 {
     async fn handle(
         &self,
@@ -298,15 +295,15 @@ impl Transaction {
     /// Please consider that event handlers may be called multiple times
     /// in this case, so they must be idempotent at least up to the point
     /// where the error occurred.
-    pub async fn process_events<STATE: 'static, TRANSACTION_CONTEXT: 'static>(
+    pub async fn process_events<
+        STATE: 'static,
+        TRANSACTION_CONTEXT: 'static,
+    >(
         &self,
         state: &mut STATE,
         handler_registry: &mut HandlerRegistry,
         transaction_context: &mut TRANSACTION_CONTEXT,
-    ) -> Result<(), EventHandlerError>
-    where
-        STATE: Clone,
-    {
+    ) -> Result<(), EventHandlerError> {
         for event in self.events.iter() {
             let event_handler = {
                 if !handler_registry

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -97,7 +97,7 @@ where
         current_state_report_interval_ms: u64,
     ) -> Self {
         TransactionStreamProcessor {
-            current_state_report_interval: Duration::from_secs(
+            current_state_report_interval: Duration::from_millis(
                 current_state_report_interval_ms,
             ),
             ..self

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -1,32 +1,33 @@
-use crate::{
-    models::Transaction,
-    stream::{TransactionStream, TransactionStreamError},
-};
+use crate::{models::Transaction, stream::TransactionStream};
 use async_trait::async_trait;
+use tokio::sync::mpsc::Receiver;
 
 /// A transaction stream that receives transactions from a channel.
 /// This is useful for controlled testing, as it allows you
 /// to send transactions to the stream as you wish.
 #[derive(Debug)]
 pub struct ChannelTransactionStream {
-    receiver: tokio::sync::mpsc::Receiver<Transaction>,
+    receiver: Option<tokio::sync::mpsc::Receiver<Transaction>>,
 }
 
 impl ChannelTransactionStream {
-    pub fn new() -> (Self, tokio::sync::mpsc::Sender<Transaction>) {
-        let (sender, receiver) = tokio::sync::mpsc::channel(100);
-        (ChannelTransactionStream { receiver }, sender)
+    pub fn new(
+        capacity: u64,
+    ) -> (Self, tokio::sync::mpsc::Sender<Transaction>) {
+        let (sender, receiver) = tokio::sync::mpsc::channel(capacity as usize);
+        (
+            ChannelTransactionStream {
+                receiver: Some(receiver),
+            },
+            sender,
+        )
     }
 }
 
 #[async_trait]
 impl TransactionStream for ChannelTransactionStream {
-    async fn next(
-        &mut self,
-    ) -> Result<Vec<Transaction>, TransactionStreamError> {
-        match self.receiver.recv().await {
-            Some(transaction) => Ok(vec![transaction]),
-            None => return Err(TransactionStreamError::Finished),
-        }
+    async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
+        Ok(self.receiver.take().expect("Receiver already taken"))
     }
+    async fn stop(&mut self) {}
 }

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -29,5 +29,6 @@ impl TransactionStream for ChannelTransactionStream {
     async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
         Ok(self.receiver.take().expect("Receiver already taken"))
     }
+    // no task is spawned, so no need to do anything on stop
     async fn stop(&mut self) {}
 }

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -1,3 +1,5 @@
+//! A transaction stream that receives transactions from a [`tokio::sync::mpsc::channel`].
+
 use crate::{models::Transaction, stream::TransactionStream};
 use async_trait::async_trait;
 use tokio::sync::mpsc::Receiver;

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -18,7 +18,7 @@ impl ChannelTransactionStream {
     ) -> (Self, tokio::sync::mpsc::Sender<Transaction>) {
         let (sender, receiver) = tokio::sync::mpsc::channel(capacity as usize);
         (
-            ChannelTransactionStream {
+            Self {
                 receiver: Some(receiver),
             },
             sender,

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -106,7 +106,7 @@ impl DatabaseFetcher {
             state_version,
             caught_up_timeout_ms,
             query_timeout_ms,
-            tx: tx,
+            tx,
         })
     }
 
@@ -158,7 +158,7 @@ impl DatabaseFetcher {
                     state_version: db_transaction.state_version as u64,
                     intent_hash: db_transaction.transaction_tree_hash,
                     confirmed_at: Some(db_transaction.round_timestamp),
-                    events: events,
+                    events,
                 }
             })
             .collect();

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -37,7 +37,7 @@ pub struct DatabaseTransactionStream {
 
 impl DatabaseTransactionStream {
     pub fn new(database_url: String) -> Self {
-        DatabaseTransactionStream {
+        Self {
             state_version: DEFAULT_STATE_VERSION,
             limit_per_page: DEFAULT_PAGE_SIZE,
             handle: None,
@@ -100,7 +100,7 @@ impl DatabaseFetcher {
             .map_err(|err| anyhow::anyhow!("Invalid database URL: {}", err))?
             .disable_statement_logging();
         let connection = sqlx::postgres::PgPool::connect_with(options).await?;
-        Ok(DatabaseFetcher {
+        Ok(Self {
             connection,
             limit_per_page,
             state_version,
@@ -255,13 +255,13 @@ pub struct EntityReference {
 impl From<EventEmitterIdentifier> for EventEmitter {
     fn from(identifier: EventEmitterIdentifier) -> Self {
         match identifier {
-            EventEmitterIdentifier::Method { entity } => EventEmitter::Method {
+            EventEmitterIdentifier::Method { entity } => Self::Method {
                 entity_address: entity.entity_address,
             },
             EventEmitterIdentifier::Function {
                 package_address,
                 blueprint_name,
-            } => EventEmitter::Function {
+            } => Self::Function {
                 package_address,
                 blueprint_name,
             },

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -1,14 +1,12 @@
 use std::{str::FromStr, time::Duration};
 
 use crate::{
-    encodings::encode_bech32m,
     models::{Event, EventEmitter, Transaction},
     stream::TransactionStream,
 };
 
 use async_trait::async_trait;
 use chrono::Utc;
-use radix_engine_common::network::NetworkDefinition;
 use serde::Deserialize;
 use sqlx::{postgres::PgConnectOptions, ConnectOptions};
 use tokio::{sync::mpsc::Receiver, time::timeout};

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -1,14 +1,14 @@
-use std::{str::FromStr, time::Duration};
+//! A transaction stream that fetches transactions from a Radix Gateway PostgreSQL database.
 
 use crate::{
     models::{Event, EventEmitter, Transaction},
     stream::TransactionStream,
 };
-
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::Deserialize;
 use sqlx::{postgres::PgConnectOptions, ConnectOptions};
+use std::{str::FromStr, time::Duration};
 use tokio::{sync::mpsc::Receiver, time::timeout};
 
 const DEFAULT_CAUGHT_UP_TIMEOUT_MS: u64 = 500;
@@ -140,15 +140,15 @@ impl DatabaseFetcher {
             .map(|db_transaction| {
                 let events = db_transaction
                     .receipt_event_emitters
-                    .iter()
-                    .zip(db_transaction.receipt_event_sbors.iter())
-                    .zip(db_transaction.receipt_event_names.iter())
+                    .into_iter()
+                    .zip(db_transaction.receipt_event_sbors.into_iter())
+                    .zip(db_transaction.receipt_event_names.into_iter())
                     .map(|((emitter, sbor), name)| Event {
-                        name: name.clone(),
-                        binary_sbor_data: sbor.clone(),
+                        name,
+                        binary_sbor_data: sbor,
                         emitter:
                             serde_json::from_value::<EventEmitterIdentifier>(
-                                emitter.clone(),
+                                emitter,
                             )
                             .expect("Should be able to decode event emitter")
                             .into(),

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -14,8 +14,8 @@ use tokio::{sync::mpsc::Receiver, time::timeout};
 const DEFAULT_CAUGHT_UP_TIMEOUT_MS: u64 = 500;
 const DEFAULT_QUERY_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_STATE_VERSION: u64 = 1;
-const DEFAULT_PAGE_SIZE: u32 = 100000;
-const DEFAULT_BUFFER_CAPACITY: u64 = 1000000;
+const DEFAULT_PAGE_SIZE: u32 = 100_000;
+const DEFAULT_BUFFER_CAPACITY: u64 = 1_000_000;
 
 /// A transaction stream that fetches transactions directly from
 /// the PostgreSQL database associated with a Radix Gateway.

--- a/src/sources/database.rs
+++ b/src/sources/database.rs
@@ -1,0 +1,256 @@
+use std::str::FromStr;
+
+use crate::{
+    models::{Event, EventEmitter, Transaction},
+    stream::TransactionStream,
+};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::Deserialize;
+use sqlx::{postgres::PgConnectOptions, ConnectOptions};
+use tokio::sync::mpsc::Receiver;
+
+const CAUGHT_UP_TIMEOUT_MS: u64 = 500;
+
+/// A transaction stream that fetches transactions directly from
+/// the PostgreSQL database associated with a Radix Gateway.
+/// It's more difficult to get access to a Radix Gateway database
+/// compared to the Gateway API itself, as Radix does not provide
+/// direct access to the database. However, the database allows you
+/// to query transactions with a much higher throughput than the
+/// Gateway API.
+#[derive(Debug)]
+pub struct DatabaseTransactionStream {
+    state_version: u64,
+    handle: Option<tokio::task::JoinHandle<()>>,
+    limit_per_page: u32,
+    capacity: u64,
+    database_url: String,
+}
+
+impl DatabaseTransactionStream {
+    pub async fn new(
+        database_url: String,
+        from_state_version: u64,
+        limit_per_page: u32,
+        capacity: u64,
+    ) -> Self {
+        DatabaseTransactionStream {
+            state_version: from_state_version,
+            limit_per_page,
+            handle: None,
+            capacity,
+            database_url,
+        }
+    }
+}
+
+/// A helper which is passed to the new task created by the stream.
+/// It keeps track of the current state version and fetches transactions
+/// from the database in batches. It sends the transactions to the
+/// processor through a channel.
+struct DatabaseFetcher {
+    connection: sqlx::Pool<sqlx::Postgres>,
+    limit_per_page: u32,
+    state_version: u64,
+    tx: tokio::sync::mpsc::Sender<Transaction>,
+}
+
+impl DatabaseFetcher {
+    async fn new(
+        database_url: String,
+        limit_per_page: u32,
+        state_version: u64,
+        tx: tokio::sync::mpsc::Sender<Transaction>,
+    ) -> Result<Self, anyhow::Error> {
+        let options = PgConnectOptions::from_str(&database_url)
+            .expect("Failed to parse database URL")
+            .disable_statement_logging();
+        let connection = sqlx::postgres::PgPool::connect_with(options).await?;
+        Ok(DatabaseFetcher {
+            connection,
+            limit_per_page,
+            state_version,
+            tx: tx,
+        })
+    }
+
+    /// Fetches the next batch of transactions from the database.
+    async fn next_batch(&mut self) -> Result<Vec<Transaction>, anyhow::Error> {
+        let transactions = sqlx::query_as!(
+            TransactionRecord,
+            r#"
+                select
+                state_version,
+                round_timestamp,
+                receipt_event_emitters,
+                receipt_event_sbors,
+                receipt_event_names,
+                transaction_tree_hash
+                from
+                ledger_transactions
+                where discriminator = 'user' and receipt_status != 'failed' and state_version >= $2
+                order by state_version asc
+                limit
+                $1
+            "#,
+            self.limit_per_page as i32,
+            self.state_version as i64
+        )
+        .fetch_all(&self.connection)
+        .await?;
+
+        let transactions: Vec<_> = transactions
+            .into_iter()
+            .map(|db_transaction| {
+                let events = db_transaction
+                    .receipt_event_emitters
+                    .iter()
+                    .zip(db_transaction.receipt_event_sbors.iter())
+                    .zip(db_transaction.receipt_event_names.iter())
+                    .map(|((emitter, sbor), name)| Event {
+                        name: name.clone(),
+                        binary_sbor_data: sbor.clone(),
+                        emitter:
+                            serde_json::from_value::<EventEmitterIdentifier>(
+                                emitter.clone(),
+                            )
+                            .unwrap()
+                            .into(),
+                    })
+                    .collect();
+                Transaction {
+                    state_version: db_transaction.state_version as u64,
+                    intent_hash: db_transaction.transaction_tree_hash,
+                    confirmed_at: Some(db_transaction.round_timestamp),
+                    events: events,
+                }
+            })
+            .collect();
+
+        self.state_version = transactions
+            .last()
+            .map(|transaction| transaction.state_version + 1)
+            .unwrap_or(self.state_version);
+
+        Ok(transactions)
+    }
+
+    async fn run(&mut self) {
+        loop {
+            let mut response = self.next_batch().await;
+            while let Err(err) = response {
+                log::error!("Error fetching transactions: {:?}", err);
+                response = self.next_batch().await;
+            }
+            let transactions = response.unwrap();
+            if transactions.is_empty() {
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    CAUGHT_UP_TIMEOUT_MS,
+                ))
+                .await;
+            }
+
+            for transaction in transactions {
+                if self.tx.send(transaction).await.is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionStream for DatabaseTransactionStream {
+    async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
+        let (tx, rx) = tokio::sync::mpsc::channel(self.capacity as usize);
+        let mut fetcher = DatabaseFetcher::new(
+            self.database_url.clone(),
+            self.limit_per_page,
+            self.state_version,
+            tx,
+        )
+        .await?;
+        let handle = tokio::spawn(async move { fetcher.run().await });
+        self.handle = Some(handle);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[derive(sqlx::FromRow, Debug)] // Ensure this derive to work with sqlx queries
+struct TransactionRecord {
+    state_version: i64,
+    round_timestamp: chrono::DateTime<Utc>,
+    receipt_event_emitters: Vec<serde_json::Value>,
+    receipt_event_sbors: Vec<Vec<u8>>,
+    receipt_event_names: Vec<String>,
+    transaction_tree_hash: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum EventEmitterIdentifier {
+    Method {
+        entity: EntityReference,
+    },
+    Function {
+        package_address: String,
+        blueprint_name: String,
+    },
+}
+
+impl From<EventEmitterIdentifier> for EventEmitter {
+    fn from(identifier: EventEmitterIdentifier) -> Self {
+        match identifier {
+            EventEmitterIdentifier::Method { entity } => EventEmitter::Method {
+                entity_address: entity.entity_address,
+            },
+            EventEmitterIdentifier::Function {
+                package_address,
+                blueprint_name,
+            } => EventEmitter::Function {
+                package_address,
+                blueprint_name,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct EntityReference {
+    pub entity_type: EntityType,
+    pub is_global: bool,
+    pub entity_address: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum EntityType {
+    GlobalPackage,
+    GlobalConsensusManager,
+    GlobalValidator,
+    GlobalGenericComponent,
+    GlobalAccount,
+    GlobalIdentity,
+    GlobalAccessController,
+    GlobalVirtualSecp256k1Account,
+    GlobalVirtualSecp256k1Identity,
+    GlobalVirtualEd25519Account,
+    GlobalVirtualEd25519Identity,
+    GlobalFungibleResource,
+    InternalFungibleVault,
+    GlobalNonFungibleResource,
+    InternalNonFungibleVault,
+    InternalGenericComponent,
+    InternalKeyValueStore,
+    GlobalOneResourcePool,
+    GlobalTwoResourcePool,
+    GlobalMultiResourcePool,
+    GlobalTransactionTracker,
+}

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -18,7 +18,7 @@ pub struct FileTransaction {
 
 impl From<FileTransaction> for Transaction {
     fn from(transaction: FileTransaction) -> Self {
-        Transaction {
+        Self {
             intent_hash: transaction.intent_hash,
             state_version: transaction.state_version,
             confirmed_at: Some(chrono::DateTime::from_timestamp_nanos(
@@ -56,7 +56,7 @@ impl FileTransactionStream {
             _ => panic!("Unsupported file type"),
         };
 
-        FileTransactionStream { transactions }
+        Self { transactions }
     }
 }
 
@@ -64,9 +64,9 @@ impl FileTransactionStream {
 impl TransactionStream for FileTransactionStream {
     async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
-        let mut transactions = self.transactions.clone();
+        let transactions = self.transactions.clone();
         tokio::spawn(async move {
-            for transaction in transactions.drain(..) {
+            for transaction in transactions.into_iter() {
                 if tx.send(transaction.into()).await.is_err() {
                     break;
                 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,3 +1,5 @@
+//! A transaction stream that fetches transactions from a YAML or JSON file.
+
 use std::{fs::File, path::Path};
 
 use async_trait::async_trait;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2,11 +2,9 @@ use std::{fs::File, path::Path};
 
 use async_trait::async_trait;
 use serde::Deserialize;
+use tokio::sync::mpsc::Receiver;
 
-use crate::{
-    models::Transaction,
-    stream::{TransactionStream, TransactionStreamError},
-};
+use crate::{models::Transaction, stream::TransactionStream};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct FileTransaction {
@@ -58,19 +56,18 @@ impl FileTransactionStream {
 
 #[async_trait]
 impl TransactionStream for FileTransactionStream {
-    async fn next(
-        &mut self,
-    ) -> Result<Vec<Transaction>, TransactionStreamError> {
-        if self.transactions.is_empty() {
-            return Err(TransactionStreamError::Finished);
-        }
-
-        let transactions = self.transactions.clone();
-        self.transactions.clear();
-        let transactions: Vec<Transaction> = transactions
-            .into_iter()
-            .map(|transaction| transaction.into())
-            .collect();
-        Ok(transactions)
+    async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        let mut transactions = self.transactions.clone();
+        tokio::spawn(async move {
+            for transaction in transactions.drain(..) {
+                if tx.send(transaction.into()).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(rx)
     }
+
+    async fn stop(&mut self) {}
 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -68,6 +68,6 @@ impl TransactionStream for FileTransactionStream {
         });
         Ok(rx)
     }
-
+    // no task is spawned, so no need to do anything on stop
     async fn stop(&mut self) {}
 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -16,15 +16,19 @@ pub struct FileTransaction {
     pub events: Vec<radix_client::gateway::models::Event>,
 }
 
-impl Into<Transaction> for FileTransaction {
-    fn into(self) -> Transaction {
+impl From<FileTransaction> for Transaction {
+    fn from(transaction: FileTransaction) -> Self {
         Transaction {
-            intent_hash: self.intent_hash,
-            state_version: self.state_version,
+            intent_hash: transaction.intent_hash,
+            state_version: transaction.state_version,
             confirmed_at: Some(chrono::DateTime::from_timestamp_nanos(
-                self.unix_timestamp_nanos,
+                transaction.unix_timestamp_nanos,
             )),
-            events: self.events.into_iter().map(|event| event.into()).collect(),
+            events: transaction
+                .events
+                .into_iter()
+                .map(|event| event.into())
+                .collect(),
         }
     }
 }

--- a/src/sources/gateway.rs
+++ b/src/sources/gateway.rs
@@ -40,7 +40,9 @@ impl Into<Event> for radix_client::gateway::models::Event {
         Event {
             name: self.name,
             emitter,
-            binary_sbor_data: programmatic_json_to_bytes(&self.data).unwrap(),
+            binary_sbor_data: programmatic_json_to_bytes(&self.data).expect(
+                "Should always able to convert Programmatic JSON to binary SBOR",
+            ),
         }
     }
 }
@@ -48,14 +50,16 @@ impl Into<Event> for radix_client::gateway::models::Event {
 impl Into<Transaction> for CommittedTransactionInfo {
     fn into(self) -> Transaction {
         Transaction {
-            intent_hash: self.intent_hash.unwrap(),
+            intent_hash: self
+                .intent_hash
+                .expect("Transaction should have tx id"),
             state_version: self.state_version,
             confirmed_at: self.confirmed_at,
             events: self
                 .receipt
-                .unwrap()
+                .expect("Transaction should have receipt")
                 .events
-                .unwrap()
+                .expect("Transaction receipt should have events")
                 .into_iter()
                 .map(|event| event.into())
                 .collect(),

--- a/src/sources/gateway.rs
+++ b/src/sources/gateway.rs
@@ -1,21 +1,20 @@
 use crate::{
     encodings::programmatic_json_to_bytes,
     models::{Event, EventEmitter, Transaction},
-    stream::{TransactionStream, TransactionStreamError},
+    stream::TransactionStream,
 };
 
 use async_trait::async_trait;
 use radix_client::{
     gateway::{
-        models::{
-            CommittedTransactionInfo, EventEmitterIdentifier,
-            LedgerStateSelector, Order, TransactionKindFilter,
-            TransactionStreamOptIns, TransactionStreamRequestBody,
-        },
-        stream::TransactionStreamAsync,
+        models::{CommittedTransactionInfo, EventEmitterIdentifier},
+        stream::stream_client::TransactionStreamAsync,
     },
     GatewayClientAsync,
 };
+use tokio::sync::mpsc::{Receiver, Sender};
+
+const CAUGHT_UP_TIMEOUT_MS: u64 = 500;
 
 impl Into<Event> for radix_client::gateway::models::Event {
     fn into(self) -> Event {
@@ -60,49 +59,95 @@ impl Into<Transaction> for CommittedTransactionInfo {
 }
 #[derive(Debug)]
 pub struct GatewayTransactionStream {
-    stream: TransactionStreamAsync,
+    gateway_url: String,
+    from_state_version: u64,
+    limit_per_page: u32,
+    capacity: u64,
+    handle: Option<tokio::task::JoinHandle<()>>,
 }
+
 impl GatewayTransactionStream {
     pub fn new(
         from_state_version: u64,
-        limit_per_page: u32,
         gateway_url: String,
+        limit_per_page: u32,
+        capacity: u64,
+    ) -> Self {
+        GatewayTransactionStream {
+            gateway_url,
+            from_state_version,
+            limit_per_page,
+            capacity,
+            handle: None,
+        }
+    }
+}
+
+struct GatewayFetcher {
+    stream: TransactionStreamAsync,
+    tx: Sender<Transaction>,
+}
+
+impl GatewayFetcher {
+    pub fn new(
+        gateway_url: String,
+        from_state_version: u64,
+        limit_per_page: u32,
+        tx: Sender<Transaction>,
     ) -> Self {
         let client = GatewayClientAsync::new(gateway_url);
-        let stream =
-            client.new_transaction_stream(TransactionStreamRequestBody {
-                from_ledger_state: Some(LedgerStateSelector {
-                    state_version: Some(from_state_version),
-                    ..Default::default()
-                }),
-                limit_per_page: Some(limit_per_page),
-                affected_global_entities_filter: None,
-                opt_ins: Some(TransactionStreamOptIns {
-                    receipt_events: true,
-                    ..Default::default()
-                }),
-                order: Some(Order::Asc),
-                kind_filter: TransactionKindFilter::User,
-                ..Default::default()
-            });
-        GatewayTransactionStream { stream }
+        let stream = TransactionStreamAsync::new(
+            &client,
+            from_state_version,
+            limit_per_page,
+        );
+        GatewayFetcher { stream, tx }
+    }
+
+    async fn run(&mut self) {
+        loop {
+            let mut response = self.stream.next().await;
+            while let Err(err) = response {
+                log::error!("Error fetching transactions: {:?}", err);
+                response = self.stream.next().await;
+            }
+            let response = response.unwrap();
+            if response.items.is_empty() {
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    CAUGHT_UP_TIMEOUT_MS,
+                ))
+                .await;
+            }
+            let transactions: Vec<Transaction> =
+                response.items.into_iter().map(|item| item.into()).collect();
+            for transaction in transactions {
+                // Stop fetching if the receiving end is closed
+                if self.tx.send(transaction).await.is_err() {
+                    return;
+                }
+            }
+        }
     }
 }
 
 #[async_trait]
 impl TransactionStream for GatewayTransactionStream {
-    async fn next(
-        &mut self,
-    ) -> Result<Vec<Transaction>, TransactionStreamError> {
-        let response = self.stream.next().await.map_err(|err| {
-            TransactionStreamError::Error(format!("{:?}", err))
-        })?;
-        let boxed: Vec<Transaction> =
-            response.items.into_iter().map(|item| item.into()).collect();
-        if boxed.is_empty() {
-            Err(TransactionStreamError::CaughtUp)
-        } else {
-            Ok(boxed)
+    async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error> {
+        let (tx, rx) = tokio::sync::mpsc::channel(self.capacity as usize);
+        let mut fetcher = GatewayFetcher::new(
+            self.gateway_url.clone(),
+            self.from_state_version,
+            self.limit_per_page,
+            tx,
+        );
+        let handle = tokio::spawn(async move { fetcher.run().await });
+        self.handle = Some(handle);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
         }
     }
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,10 +1,4 @@
 pub mod channel;
-
 pub mod database;
 pub mod file;
 pub mod gateway;
-
-pub enum ChannelStatus {
-    Open,
-    Closed,
-}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,3 +1,10 @@
 pub mod channel;
+
+pub mod database;
 pub mod file;
 pub mod gateway;
+
+pub enum ChannelStatus {
+    Open,
+    Closed,
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,7 +1,16 @@
 //! Implementations of [`TransactionStream`][crate::stream::TransactionStream] provided by
 //! the framework.
+//!
+//! It is possible to opt in to these implementations by enabling
+//! the corresponding feature flags. It is recommended to use feature flags
+//! to only include the implementations that are needed for your use case,
+//! because this allows you to skip some optional dependencies.
 
+#[cfg(feature = "channel")]
 pub mod channel;
+#[cfg(feature = "database")]
 pub mod database;
+#[cfg(feature = "file")]
 pub mod file;
+#[cfg(feature = "gateway")]
 pub mod gateway;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,3 +1,6 @@
+//! Implementations of [`TransactionStream`][crate::stream::TransactionStream] provided by
+//! the framework.
+
 pub mod channel;
 pub mod database;
 pub mod file;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,9 +8,9 @@ use tokio::sync::mpsc::Receiver;
 
 /// A trait that abstracts a stream of transactions coming
 /// from any source, like a gateway, database, or file.
-/// The stream is started by calling [`TransactionStream::start`], which returns
-/// a [`tokio::sync::mpsc::Receiver`] that the [`TransactionStreamProcessor`] awaits
-/// on to receive transactions.
+/// The stream is started by calling [`TransactionStream::start`][crate::stream::TransactionStream], which returns
+/// a [`tokio::sync::mpsc::Receiver`] that the [`TransactionStreamProcessor`][crate::processor::TransactionStreamProcessor]
+/// awaits on to receive transactions.
 ///
 /// If the stream is finished, which can happen when processing
 /// a finite source of transactions such as a file, the stream

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,24 +1,37 @@
 use crate::models::Transaction;
 use async_trait::async_trait;
 use std::fmt::Debug;
+use tokio::sync::mpsc::Receiver;
 
 /// A trait that abstracts a stream of transactions coming
 /// from any source, like a gateway, database, or file.
+/// The stream is started by calling `start`, which returns
+/// a receiver that you can await on to receive transactions.
+///
+/// If the stream is finished, which can happen when processing
+/// a finite source of transactions such as a file, the stream
+/// should simply close the channel and the processor will exit
+/// gracefully.
+///
+/// If a stream, like a gateway stream, is caught up, it may be
+/// possible that there are no transactions to push to the channel.
+/// In this case, the processor will simply wait until there are
+/// transactions available, which is the default behavior when calling
+/// `recv().await` on a receiver.
+///
+/// If the channel is full, the stream will wait until there is space
+/// in the channel to push the transaction. This is the default behavior
+/// when calling `send().await` on a sender.
+///
+/// If the processor errors, it drops the receiver, which a stream
+/// will use to detect that it no longer needs to fetch transactions.
+/// An explicit stop() method is still useful in more advanced cases.
 #[async_trait]
 pub trait TransactionStream: Debug {
-    async fn next(
-        &mut self,
-    ) -> Result<Vec<Transaction>, TransactionStreamError>;
-}
+    // Starts the stream. This may involve spawning a new task,
+    // which pushes transactions to the channel that is returned.
+    async fn start(&mut self) -> Result<Receiver<Transaction>, anyhow::Error>;
 
-#[derive(Debug)]
-pub enum TransactionStreamError {
-    /// The stream is caught up with the latest transactions.
-    /// The processor should wait for new transactions and try again.
-    CaughtUp,
-    /// The stream is finished and there are no more transactions.
-    /// The processor should stop processing transactions.
-    Finished,
-    /// An error occurred while processing the stream.
-    Error(String),
+    // Explicitly stop the stream
+    async fn stop(&mut self);
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,6 @@
+//! Has a trait that abstracts a stream of transactions coming
+//! from any source, like a gateway, database, or file.
+
 use crate::models::Transaction;
 use async_trait::async_trait;
 use std::fmt::Debug;
@@ -5,26 +8,28 @@ use tokio::sync::mpsc::Receiver;
 
 /// A trait that abstracts a stream of transactions coming
 /// from any source, like a gateway, database, or file.
-/// The stream is started by calling `start`, which returns
-/// a receiver that you can await on to receive transactions.
+/// The stream is started by calling [`TransactionStream::start`], which returns
+/// a [`tokio::sync::mpsc::Receiver`] that the [`TransactionStreamProcessor`] awaits
+/// on to receive transactions.
 ///
 /// If the stream is finished, which can happen when processing
 /// a finite source of transactions such as a file, the stream
 /// should simply close the channel and the processor will exit
 /// gracefully.
 ///
-/// If a stream, like a gateway stream, is caught up, it may be
-/// possible that there are no transactions to push to the channel.
+/// If a stream, like a Gateway stream, is caught up to the latest state, it may be
+/// possible that there are no transactions to push to the channel for a while.
 /// In this case, the processor will simply wait until there are
-/// transactions available, which is the default behavior when calling
+/// transactions available in the channel, which is the default behavior when calling
 /// `recv().await` on a receiver.
 ///
-/// If the channel is full, the stream will wait until there is space
+/// If the channel is full, the stream will wait with fetching until there is space
 /// in the channel to push the transaction. This is the default behavior
 /// when calling `send().await` on a sender.
 ///
-/// If the processor errors, it drops the receiver, which a stream
-/// will use to detect that it no longer needs to fetch transactions.
+/// If the processor fails, it drops the receiver, which a stream can implicitly
+/// use to detect that it no longer needs to fetch transactions.
+/// This is recommended to avoid leaking a fetching task.
 /// An explicit stop() method is still useful in more advanced cases.
 #[async_trait]
 pub trait TransactionStream: Debug {

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -3,15 +3,11 @@ use crate::{
     models::Transaction,
 };
 use async_trait::async_trait;
-use dyn_clone::DynClone;
 
 /// A trait that abstracts a transaction handler.
 #[allow(non_camel_case_types)]
 #[async_trait]
-pub trait TransactionHandler<STATE>: DynClone
-where
-    STATE: Clone,
-{
+pub trait TransactionHandler<STATE> {
     async fn handle(
         &self,
         input: TransactionHandlerContext<'_, STATE>,
@@ -19,22 +15,9 @@ where
 }
 
 #[allow(non_camel_case_types)]
-impl<STATE> Clone for Box<dyn TransactionHandler<STATE>>
-where
-    STATE: Clone,
-{
-    fn clone(&self) -> Self {
-        dyn_clone::clone_box(&**self)
-    }
-}
-
-#[allow(non_camel_case_types)]
 /// A struct that holds the context for a transaction handler,
 /// which is passed to the handler when it is called.
-pub struct TransactionHandlerContext<'a, STATE>
-where
-    STATE: Clone,
-{
+pub struct TransactionHandlerContext<'a, STATE> {
     pub state: &'a mut STATE,
     pub transaction: &'a Transaction,
     pub handler_registry: &'a mut HandlerRegistry,

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::TransactionHandlerError, event_handler::HandlerRegistry,
-    models::Transaction,
+    models::Transaction, processor::EventProcessor,
 };
 use async_trait::async_trait;
 
@@ -20,5 +20,6 @@ pub trait TransactionHandler<STATE> {
 pub struct TransactionHandlerContext<'a, STATE> {
     pub state: &'a mut STATE,
     pub transaction: &'a Transaction,
+    pub event_processor: &'a mut EventProcessor<'a>,
     pub handler_registry: &'a mut HandlerRegistry,
 }

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -1,13 +1,85 @@
+/*!
+The interface for a [`TransactionHandler`]
+
+Transaction handlers are responsible for processing transactions
+and calling event handlers to process the events
+inside the transaction.
+The transaction handler is only called when a transaction actually has events
+that have an event handler associated with them.
+
+We don't generally have to create a separate struct
+and implement this trait for it manually, because we can use
+the `#[transaction_handler]` macro to generate the
+struct and implementation for us. It allows us to write
+the handler as an async function, which is a bit more
+ergonomic.
+To use this macro, the handler function must conform to a predefined
+signature.
+A transaction handler function must:
+- Be an async function
+- Take a single argument of type `TransactionHandlerContext<YOUR_STATE>`
+- Return a `Result<(), TransactionHandlerError>`
+
+You can use the following template to create a transaction handler:
+```ignore
+#[transaction_handler]
+// Function name is the name of your handler
+async fn transaction_handler_name(
+    // Context the handler will get from the framework.
+    // This includes the current ledger transaction we're in
+    // and the global state. It is parametrized by the
+    // app state and the transaction context type, but the context is optional,
+    // and defaults to the unit type.
+    context: TransactionHandlerContext<YOUR_STATE>,
+) -> Result<(), TransactionHandlerError> {
+    // Do something like start a database transaction
+    let mut transaction_context = TransactionContext { tx: start_transaction() }
+    // Handle the events inside the incoming transaction.
+    // We provide a simple method for this.
+    context
+        .event_processor
+        .process_events(
+            context.state,
+            context.handler_registry,
+            // the transaction context is passed in
+            &mut transaction_context,
+        )
+        // EventHandlerErrors can be cast into TransactionHandlerErrors,
+        // and the framework will handle these appropriately.
+        // So, best to propagate these with the ? operator.
+        .await?;
+    // Possible errors to return:
+    // Retry handling the current transaction
+    return Err(EventHandlerError::TransactionRetryError(
+        anyhow!("Retry transaction because of...")
+    ));
+    // Stop the stream
+    return Err(EventHandlerError::UnrecoverableError(
+        anyhow!("Stream failed because of...")
+    ));
+    // Everything's ok!
+    Ok(())
+}
+```
+Now, we can simply pass in the handler to the [`TransactionStreamProcessor`][crate::processor::TransactionStreamProcessor].
+It is now secretly a struct that implements the [`TransactionHandler`] trait.
+*/
+
+/// A trait that defines a transaction handler.
+/// A transaction handler is responsible for
+/// calling event handlers to process the events
+/// in a transaction, and potentially doing
+/// database transactions or other atomic operations at the
+/// transaction level.
 use crate::{
     error::TransactionHandlerError, event_handler::HandlerRegistry,
     models::Transaction, processor::EventProcessor,
 };
 use async_trait::async_trait;
 
-/// A trait that abstracts a transaction handler.
 #[allow(non_camel_case_types)]
 #[async_trait]
-pub trait TransactionHandler<STATE> {
+pub trait TransactionHandler<STATE>: 'static {
     async fn handle(
         &self,
         input: TransactionHandlerContext<'_, STATE>,

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -8,19 +8,18 @@ use dyn_clone::DynClone;
 /// A trait that abstracts a transaction handler.
 #[allow(non_camel_case_types)]
 #[async_trait]
-pub trait TransactionHandler<STATE, TRANSACTION_CONTEXT>: DynClone
+pub trait TransactionHandler<STATE>: DynClone
 where
     STATE: Clone,
 {
     async fn handle(
         &self,
-        input: TransactionHandlerContext<'_, STATE, TRANSACTION_CONTEXT>,
+        input: TransactionHandlerContext<'_, STATE>,
     ) -> Result<(), TransactionHandlerError>;
 }
 
 #[allow(non_camel_case_types)]
-impl<STATE, TRANSACTION_CONTEXT> Clone
-    for Box<dyn TransactionHandler<STATE, TRANSACTION_CONTEXT>>
+impl<STATE> Clone for Box<dyn TransactionHandler<STATE>>
 where
     STATE: Clone,
 {
@@ -32,11 +31,11 @@ where
 #[allow(non_camel_case_types)]
 /// A struct that holds the context for a transaction handler,
 /// which is passed to the handler when it is called.
-pub struct TransactionHandlerContext<'a, STATE, TRANSACTION_CONTEXT = ()>
+pub struct TransactionHandlerContext<'a, STATE>
 where
     STATE: Clone,
 {
     pub state: &'a mut STATE,
     pub transaction: &'a Transaction,
-    pub handler_registry: &'a mut HandlerRegistry<STATE, TRANSACTION_CONTEXT>,
+    pub handler_registry: &'a mut HandlerRegistry,
 }


### PR DESCRIPTION
Notable changes:
- Changed interface of transaction streams. Instead of only fetching when they are pulled from, they may start a task and independently fetch transactions by buffering them to a channel. The processor receives transactions from the receiver end of the channel. Instead of communicating the state of the stream with the processor, they act implicitly. If the receiving end is dropped by the processor, the fetching task is also terminated. If the sender end is dropped, the processor assumes there are no more transactions and exits gracefully. If the channel is empty, the processor will simply wait until new transactions are pushed to it, which is the default behavior is of recv().await.
- Changed HandlerRegistry (for events) to a type-erased version. This means it is no longer parametrized by any types. This means the user has to write a bit less boilerplate code and some of the types are a bit less verbose.
- Implemented database stream.
- Added a builder pattern for some of the transaction streams. They were getting a bit too many params, so some sensible defaults + a builder should alleviate that.
- Removed requirement of Clone for STATE, as it is not necessary.
- Updated to new radix-client style gateway stream
- Implement custom logging via an interface of hooks
- Provide a default implementation of a logger
- Use the new builder-style pattern of the radix-client
- Added license-file and repository metadata to Cargo.toml
